### PR TITLE
DATAGO-80480: Add shareable hatch workflows

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+### What is the purpose of this change?
+
+    ...
+
+### How is this accomplished?
+
+    ...
+
+### Anything reviews should focus on/be aware of?
+
+    ...

--- a/.github/actions/hatch-lint-test-sonar/action.yml
+++ b/.github/actions/hatch-lint-test-sonar/action.yml
@@ -1,0 +1,98 @@
+name: hatch-lint-test-sonar
+description: Hatch install with support for caching of dependency groups.
+inputs:
+  min-python-version:
+    description: "Minimum Python version to test with."
+    default: "3.8"
+  max-python-version:
+    description: "Maximum Python version to test with."
+    default: "3.12"
+  SONAR_HOST_URL:
+    description: "SonarQube host URL for the repository."
+    required: true
+  SONAR_TOKEN:
+    description: "SonarQube token for the repository."
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Run Lint
+      continue-on-error: true
+      run: |
+        hatch run hatch-static-analysis:ruff check -o lint.json --output-format json
+      shell: bash
+
+    - name: Run Unit Tests
+      continue-on-error: true
+      shell: bash
+      run: |
+        hatch test --python ${{ inputs.min-python-version }}  --cover --parallel --junitxml=junit.xml
+        hatch test --python ${{ inputs.max-python-version }}  --cover --parallel --junitxml=junit.xml
+
+    - name: Combine Coverage Reports
+      continue-on-error: true
+      run: |
+        hatch run hatch-test.py${{ inputs.max-python-version }}:coverage combine
+      shell: bash
+
+    - name: Report coverage
+      continue-on-error: true
+      run: |
+        hatch run hatch-test.py${{ inputs.max-python-version }}:coverage xml
+      shell: bash
+
+    - name: SonarQube Scan
+      if: always() && github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+      uses: sonarsource/sonarqube-scan-action@v2.2.0
+      env:
+        SONAR_TOKEN: ${{ inputs.SONAR_TOKEN }}
+        SONAR_HOST_URL: ${{ inputs.SONAR_HOST_URL }}
+      with:
+        args: >
+          -Dsonar.tests=tests/
+          -Dsonar.verbose=true
+          -Dsonar.sources=src/
+          -Dsonar.projectKey=${{github.repository_owner}}_${{github.event.repository.name}}
+          -Dsonar.python.coverage.reportPaths=coverage.xml
+          -Dsonar.python.ruff.reportPaths=lint.json
+
+    - name: SonarQube Quality Gate check
+      id: sonarqube-quality-gate-check
+      uses: sonarsource/sonarqube-quality-gate-action@master
+      env:
+        SONAR_TOKEN: ${{ inputs.SONAR_TOKEN }}
+        SONAR_HOST_URL: ${{ inputs.SONAR_HOST_URL }}
+
+    # Build and verify packages
+    - name: Build
+      shell: bash
+      run: hatch build
+
+    - name: Verify Packages
+      run: |
+        ls dist/*.tar.gz | xargs -n1 hatch run python -m twine check
+        ls dist/*.whl | xargs -n1 hatch run python -m twine check
+      shell: bash
+
+    - name: Surface failing tests
+      if: always() && github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+      uses: pmeier/pytest-results-action@main
+      with:
+        # A list of JUnit XML files, directories containing the former, and wildcard
+        # patterns to process.
+        # See @actions/glob for supported patterns.
+        path: junit.xml
+
+        # (Optional) Add a summary of the results at the top of the report
+        summary: true
+
+        # (Optional) Select which results should be included in the report.
+        # Follows the same syntax as `pytest -r`
+        display-options: fEX
+
+        # (Optional) Fail the workflow if no JUnit XML was found.
+        fail-on-empty: true
+
+        # (Optional) Title of the test results section in the workflow summary
+        title: Unit Test results

--- a/.github/actions/hatch-setup/action.yml
+++ b/.github/actions/hatch-setup/action.yml
@@ -1,0 +1,61 @@
+name: hatch-install-with-caching
+description: Hatch install with support for caching of dependency groups.
+inputs:
+  min-python-version:
+    description: "Minimum Python version to support."
+    default: "3.8"
+  max-python-version:
+    description: "Maximum Python version to support."
+    default: "3.12"
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Hatch Environment
+      run: |
+        echo "HATCH_CACHE_DIR=${{ github.workspace }}/.hatch_cache" >> $GITHUB_ENV
+        echo "HATCH_DATA_DIR=${{ github.workspace }}/.hatch_data" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Verify 'pyproject.toml' exists)
+      run: test -f pyproject.toml
+      shell: bash
+
+    - name: Install Hatch
+      uses: pypa/hatch@install
+
+    - name: Restore Hatch Directory
+      uses: actions/cache/restore@v4
+      id: cache-restore
+      with:
+        path: |
+          ${{ env.HATCH_CACHE_DIR }}
+          ${{ env.HATCH_DATA_DIR }}
+        key: ${{ runner.os }}-hatch-${{ hashFiles('pyproject.toml') }}
+
+    - name: Install Dependencies
+      shell: bash
+      if: steps.cache-restore.outputs.cache-hit != 'true'
+      run: |
+        hatch python install ${{ inputs.min-python-version }} ${{ inputs.max-python-version }}
+
+    - name: Install Dependencies
+      shell: bash
+      if: steps.cache-restore.outputs.cache-hit != 'true'
+      run: |
+        hatch env create
+
+    - name: Install Twine
+      shell: bash
+      run: |
+        hatch run python -m pip install twine
+
+    - name: Cache Hatch Directory
+      uses: actions/cache/save@v4
+      if: steps.cache-restore.outputs.cache-hit != 'true'
+      id: cache-hatch
+      with:
+        path: |
+          ${{ env.HATCH_CACHE_DIR }}
+          ${{ env.HATCH_DATA_DIR }}
+        key: ${{ runner.os }}-hatch-${{ hashFiles('pyproject.toml') }}

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -3,9 +3,6 @@ name: Release to PyPi with Hatch
 on:
   workflow_call:
     secrets:
-      COMMIT_KEY:
-        description: "SSH private key for the repository."
-        required: true
       SONAR_TOKEN:
         description: "SonarQube token for the repository."
         required: true

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -1,0 +1,37 @@
+name: Release to PyPi with Hatch
+
+on:
+  workflow_call:
+    secrets:
+      COMMIT_KEY:
+        description: "SSH private key for the repository."
+        required: true
+      SONAR_TOKEN:
+        description: "SonarQube token for the repository."
+        required: true
+      SONAR_HOST_URL:
+        description: "SonarQube host URL for the repository."
+        required: true
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  build:
+    name: Lint, Test, and Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Hatch
+        uses: SolaceDev/solace-public-workflows/.github/actions/hatch-setup@hatch_workflows
+
+      - name: Lint, Test and Build
+        uses: SolaceDev/solace-public-workflows/.github/actions/hatch-lint-test-sonar@hatch_workflows
+        with:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -14,6 +14,10 @@ permissions:
   id-token: write
   contents: write
 
+env:
+  min-python-version: "3.8"
+  max-python-version: "3.12"
+
 jobs:
   build:
     name: Lint, Test, and Build
@@ -25,10 +29,87 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Hatch
-        uses: SolaceDev/solace-public-workflows/.github/actions/hatch-setup@hatch_workflows
-
-      - name: Lint, Test and Build
-        uses: SolaceDev/solace-public-workflows/.github/actions/hatch-lint-test-sonar@hatch_workflows
+        uses: SolaceDev/solace-public-workflows/.github/actions/hatch-setup@v1.0.0
         with:
+          min-python-version: ${{ env.min-python-version }}
+          max-python-version: ${{ env.max-python-version }}
+
+      - name: Run Lint
+        continue-on-error: true
+        run: |
+          hatch run hatch-static-analysis:ruff check -o lint.json --output-format json
+        shell: bash
+
+      - name: Run Unit Tests
+        continue-on-error: true
+        shell: bash
+        run: |
+          hatch test --python ${{ env.min-python-version }}  --cover --parallel --junitxml=junit.xml
+          hatch test --python ${{ env.max-python-version }}  --cover --parallel --junitxml=junit.xml
+
+      - name: Combine Coverage Reports
+        continue-on-error: true
+        run: |
+          hatch run hatch-test.py${{ env.max-python-version }}:coverage combine
+        shell: bash
+
+      - name: Report coverage
+        continue-on-error: true
+        run: |
+          hatch run hatch-test.py${{ env.max-python-version }}:coverage xml
+        shell: bash
+
+      - name: SonarQube Scan
+        if: always() && github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: sonarsource/sonarqube-scan-action@v2.2.0
+        env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+        with:
+          args: >
+            -Dsonar.tests=tests/
+            -Dsonar.verbose=true
+            -Dsonar.sources=src/
+            -Dsonar.projectKey=${{github.repository_owner}}_${{github.event.repository.name}}
+            -Dsonar.python.coverage.reportPaths=coverage.xml
+            -Dsonar.python.ruff.reportPaths=lint.json
+
+      - name: SonarQube Quality Gate check
+        id: sonarqube-quality-gate-check
+        uses: sonarsource/sonarqube-quality-gate-action@master
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+
+      # Build and verify packages
+      - name: Build
+        shell: bash
+        run: hatch build
+
+      - name: Verify Packages
+        run: |
+          ls dist/*.tar.gz | xargs -n1 hatch run python -m twine check
+          ls dist/*.whl | xargs -n1 hatch run python -m twine check
+        shell: bash
+
+      - name: Surface failing tests
+        if: always() && github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: pmeier/pytest-results-action@main
+        with:
+          # A list of JUnit XML files, directories containing the former, and wildcard
+          # patterns to process.
+          # See @actions/glob for supported patterns.
+          path: junit.xml
+
+          # (Optional) Add a summary of the results at the top of the report
+          summary: true
+
+          # (Optional) Select which results should be included in the report.
+          # Follows the same syntax as `pytest -r`
+          display-options: fEX
+
+          # (Optional) Fail the workflow if no JUnit XML was found.
+          fail-on-empty: true
+
+          # (Optional) Title of the test results section in the workflow summary
+          title: Unit Test results

--- a/.github/workflows/hatch_release.yml
+++ b/.github/workflows/hatch_release.yml
@@ -1,0 +1,74 @@
+name: Release to PyPi with Hatch
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Version to release."
+        type: string
+        required: true
+      pypi-project:
+        description: "PyPi repository to release to."
+        type: string
+        required: true
+    secrets:
+      COMMIT_KEY:
+        description: "SSH private key for the repository."
+        required: true
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  release:
+    name: release to PyPi
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/${{ inputs.pypi-project }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Hatch
+        uses: SolaceDev/solace-public-workflows/.github/actions/hatch-setup@hatch_workflows
+
+      - name: Get Current Version
+        run: |
+          CURRENT_VERSION=$(hatch version)
+          echo "CURRENT_VERSION=${CURRENT_VERSION}" >> $GITHUB_ENV
+
+      - name: Fail if the current version doesn't exist
+        if: env.CURRENT_VERSION == ''
+        run: exit 1
+
+      - name: Build project for distribution
+        run: hatch build
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "dist/*.whl"
+          makeLatest: true
+          generateReleaseNotes: true
+          tag: ${{ env.CURRENT_VERSION }}
+
+      - name: Bump Version
+        run: |
+          hatch version "${{ github.event.inputs.version }}"
+          NEW_VERSION=$(hatch version)
+          echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_ENV
+
+      - name: Commit new version
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git commit -a -m "[ci skip] Bump version to $NEW_VERSION"
+          git push

--- a/.github/workflows/hatch_release_pypi.yml
+++ b/.github/workflows/hatch_release_pypi.yml
@@ -15,7 +15,6 @@ on:
       COMMIT_KEY:
         description: "SSH private key for the repository."
         required: true
-
 permissions:
   id-token: write
   contents: write
@@ -33,6 +32,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ssh-key: ${{ secrets.COMMIT_KEY }}
 
       - name: Set up Hatch
         uses: SolaceDev/solace-public-workflows/.github/actions/hatch-setup@hatch_workflows

--- a/.github/workflows/hatch_release_pypi.yml
+++ b/.github/workflows/hatch_release_pypi.yml
@@ -35,7 +35,7 @@ jobs:
           ssh-key: ${{ secrets.COMMIT_KEY }}
 
       - name: Set up Hatch
-        uses: SolaceDev/solace-public-workflows/.github/actions/hatch-setup@hatch_workflows
+        uses: SolaceDev/solace-public-workflows/.github/actions/hatch-setup@v1.0.0
 
       - name: Get Current Version
         run: |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
 # Shareable Workflows for Solace Organization
 
-This repository hosts a collection of GitHub Actions workflows that are shareable and reusable across various repositories within the Solace organization, including **SolaceProducts**, **SolaceDev**, and **SolaceLabs**.
-
-## Support
-
-For support or questions regarding these workflows, please contact @cicd on slack
+This repository hosts a collection of public GitHub Actions workflows to be used in public Solace repositories.


### PR DESCRIPTION
### What is the purpose of this change?

Create reusable workflows to be used in public Solace repositories

### How is this accomplished?

Add reusable workflows for build, lint and test pipeline with hatch 
Add an action to setup hatch with cached dependencies
Add a release workflow that builds the wheel and publishes to pypi


### Anything reviews should focus on/be aware of?

Caching strategy for hatch setup
