### PR TITLE
Use API token when releasing to PYPI

### DIFF
--- a/.github/workflows/hatch_release_pypi.yml
+++ b/.github/workflows/hatch_release_pypi.yml
@@ -15,6 +15,9 @@ on:
       COMMIT_KEY:
         description: "SSH private key for the repository."
         required: true
+      PYPI_TOKEN:
+        description: "PyPi token"
+        required: true
 permissions:
   id-token: write
   contents: write
@@ -24,9 +27,6 @@ jobs:
     name: release to PyPi
     timeout-minutes: 20
     runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/project/${{ inputs.pypi-project }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -51,6 +51,9 @@ jobs:
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://pypi.org/project/${{ inputs.pypi-project }}
+          password: ${{ secrets.PYPI_TOKEN }}
 
       - name: Create Release
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
[DATAGO-83398](https://sol-jira.atlassian.net/browse/DATAGO-83398)
### What is the purpose of this change?

PYPI  currently does not allow trusted publishers for reusable workflows 
So we need to use PYPI API token to release using the action

### Anything reviews should focus on/be aware of?

See also 
[PR to solace-ai-connector](https://github.com/SolaceDev/solace-ai-connector/pull/21)

[DATAGO-83398]: https://sol-jira.atlassian.net/browse/DATAGO-83398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ