### PR TITLE
DATAGO-85800: Make a relase with the  newest version

### DIFF
--- a/.github/workflows/hatch_release_pypi.yml
+++ b/.github/workflows/hatch_release_pypi.yml
@@ -51,6 +51,19 @@ jobs:
         if: env.CURRENT_VERSION == ''
         run: exit 1
 
+      - name: Bump Version
+        run: |
+          hatch version "${{ github.event.inputs.version }}"
+          NEW_VERSION=$(hatch version)
+          echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_ENV
+
+      - name: Commit new version
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git commit -a -m "[ci skip] Bump version to $NEW_VERSION"
+          git push
+
       - name: Build project for distribution
         run: hatch build
 
@@ -58,12 +71,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_TOKEN }}
-
-      - name: Bump Version
-        run: |
-          hatch version "${{ github.event.inputs.version }}"
-          NEW_VERSION=$(hatch version)
-          echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_ENV
 
       - name: Create Release
         uses: ncipollo/release-action@v1
@@ -74,10 +81,3 @@ jobs:
           makeLatest: true
           generateReleaseNotes: true
           tag: ${{ env.NEW_VERSION }}
-
-      - name: Commit new version
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git commit -a -m "[ci skip] Bump version to $NEW_VERSION"
-          git push

--- a/.github/workflows/hatch_release_pypi.yml
+++ b/.github/workflows/hatch_release_pypi.yml
@@ -59,19 +59,21 @@ jobs:
         with:
           password: ${{ secrets.PYPI_TOKEN }}
 
-      - name: Create Release
-        uses: ncipollo/release-action@v1
-        with:
-          artifacts: "dist/*.whl"
-          makeLatest: true
-          generateReleaseNotes: true
-          tag: ${{ env.CURRENT_VERSION }}
-
       - name: Bump Version
         run: |
           hatch version "${{ github.event.inputs.version }}"
           NEW_VERSION=$(hatch version)
           echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_ENV
+
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        env:
+          NEW_VERSION: ${{ env.NEW_VERSION }}
+        with:
+          artifacts: "dist/*.whl"
+          makeLatest: true
+          generateReleaseNotes: true
+          tag: ${{ env.NEW_VERSION }}
 
       - name: Commit new version
         run: |


### PR DESCRIPTION
### What is the purpose of this change?

The release pipeline was releasing current version of the connector as opposed to the bumped version
This fixes it so that the newest version of the connector is released 
