### PR TITLE
DATAGO-88864 - Add annotation and improve test's on 2 python versions

### DIFF
--- a/.github/actions/hatch-setup/action.yml
+++ b/.github/actions/hatch-setup/action.yml
@@ -76,7 +76,7 @@ runs:
       shell: bash
       if: hashFiles('requirements.txt') != '' && steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'false'
       run: |
-        hatch run pip install -r requirements.txt
+        hatch run pip install --upgrade -r requirements.txt
 
     - name: Install test dependencies for default python version
       shell: bash
@@ -88,5 +88,5 @@ runs:
       shell: bash
       if: hashFiles('requirements.txt') != '' && steps.cache.outputs.cache-hit != 'true' && failure() && steps.test-matrix-present.outputs.matrix-present == 'true'
       run: |
-        hatch run hatch-test.py${{ inputs.min-python-version }}:pip install -r requirements.txt
-        hatch run hatch-test.py${{ inputs.max-python-version }}:pip install -r requirements.txt
+        hatch run hatch-test.py${{ inputs.min-python-version }}:pip install --upgrade -r requirements.txt
+        hatch run hatch-test.py${{ inputs.max-python-version }}:pip install --upgrade -r requirements.txt

--- a/.github/actions/hatch-setup/action.yml
+++ b/.github/actions/hatch-setup/action.yml
@@ -52,6 +52,7 @@ runs:
       id: test-matrix-present
       shell: bash
       run: |
+        # Verify if hatch specific test matrix is present in pyproject.toml
         MATRIX_PRESENT=$(awk -v min="${{ inputs.min-python-version }}" -v max="${{ inputs.max-python-version }}" '
             /\[tool\.hatch\.envs\.hatch-test\]/ { in_env=1; next }
             in_env && /installer = "pip"/ { has_pip_installer=1; in_env=0 }

--- a/.github/actions/hatch-setup/action.yml
+++ b/.github/actions/hatch-setup/action.yml
@@ -82,7 +82,7 @@ runs:
       shell: bash
       if: steps.test-matrix-present.outputs.matrix-present == 'false'
       run: |
-        hatch run pip install twine pytest
+        hatch run pip install twine pytest pytest-cov
 
     - name: Install Requirements.txt Dependencies for test matrix python version
       shell: bash

--- a/.github/actions/hatch-setup/action.yml
+++ b/.github/actions/hatch-setup/action.yml
@@ -10,7 +10,7 @@ inputs:
 outputs:
   matrix-present:
     description: "Whether the test matrix is present."
-    value: ${{ steps.test-matrix-present.outputs.MATRIX_PRESENT == 'true' }}
+    value: ${{ steps.test-matrix-present.outputs.matrix-present == 'true' }}
 runs:
   using: composite
   steps:
@@ -70,7 +70,7 @@ runs:
               exit 0
             }
           ' pyproject.toml)
-        echo "MATRIX_PRESENT=${{ MATRIX_PRESENT }}" >> $GITHUB_OUTPUT
+        echo "matrix-present=$MATRIX_PRESENT" >> $GITHUB_OUTPUT
 
     - name: Install Requirements.txt Dependencies for default python version
       shell: bash

--- a/.github/actions/hatch-setup/action.yml
+++ b/.github/actions/hatch-setup/action.yml
@@ -86,7 +86,7 @@ runs:
 
     - name: Install Requirements.txt Dependencies for test matrix python version
       shell: bash
-      if: hashFiles('requirements.txt') != '' && steps.cache.outputs.cache-hit != 'true' && failure() && steps.test-matrix-present.outputs.matrix-present == 'true'
+      if: hashFiles('requirements.txt') != '' && steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'true'
       run: |
         hatch run hatch-test.py${{ inputs.min-python-version }}:pip install --upgrade -r requirements.txt
         hatch run hatch-test.py${{ inputs.max-python-version }}:pip install --upgrade -r requirements.txt

--- a/.github/actions/hatch-setup/action.yml
+++ b/.github/actions/hatch-setup/action.yml
@@ -80,7 +80,7 @@ runs:
 
     - name: Install test dependencies for default python version
       shell: bash
-      if: steps.test-matrix-present.outputs.matrix-present == 'false'
+      if: steps.cache.outputs.cache-hit != 'true'
       run: |
         hatch run pip install twine pytest pytest-cov
 

--- a/.github/actions/hatch-setup/action.yml
+++ b/.github/actions/hatch-setup/action.yml
@@ -10,7 +10,7 @@ inputs:
 outputs:
   matrix-present:
     description: "Whether the test matrix is present."
-    value: ${{ steps.test-matrix-present.outputs.matrix-present == 'true' }}
+    value: ${{ steps.test-matrix-present.outputs.MATRIX_PRESENT == 'true' }}
 runs:
   using: composite
   steps:

--- a/.github/actions/hatch-setup/action.yml
+++ b/.github/actions/hatch-setup/action.yml
@@ -7,7 +7,10 @@ inputs:
   max-python-version:
     description: "Maximum Python version to support."
     default: "3.12"
-
+outputs:
+  matrix-present:
+    description: "Whether the test matrix is present."
+    value: ${{ steps.test-matrix-present.outputs.matrix-present == 'true' }}
 runs:
   using: composite
   steps:
@@ -45,16 +48,48 @@ runs:
       run: |
         hatch env create
 
-    - name: Install Twine
+    - name: Test Matrix Present
+      id: test-matrix-present
       shell: bash
       run: |
-        hatch run python -m pip install twine
+        MATRIX_PRESENT=$(awk -v min="${{ inputs.min-python-version }}" -v max="${{ inputs.max-python-version }}" '
+            /\[tool\.hatch\.envs\.hatch-test\]/ { in_env=1; next }
+            in_env && /installer = "pip"/ { has_pip_installer=1; in_env=0 }
+            /\[\[tool\.hatch\.envs\.hatch-test\.matrix\]\]/ { in_matrix=1; next }
+            in_matrix && /python = \[/ {
+              if (index($0, min)) found_min=1
+              if (index($0, max)) found_max=1
+              in_matrix=0
+            }
+            END {
+              if (!has_pip_installer || !found_min || !found_max) {
+                print "false"
+                exit 0
+              }
+              print "true"
+              exit 0
+            }
+          ' pyproject.toml)
+        echo "MATRIX_PRESENT=${{ MATRIX_PRESENT }}" >> $GITHUB_OUTPUT
 
-    - name: Install Requirements.txt Dependencies
+    - name: Install Requirements.txt Dependencies for default python version
       shell: bash
-      if: hashFiles('requirements.txt') != '' && steps.cache-restore.outputs.cache-hit != 'true'
+      if: hashFiles('requirements.txt') != '' && steps.cache-restore.outputs.cache-hit != 'true' && failure() && steps.test-matrix-present.outputs.matrix-present == 'false'
       run: |
         hatch run pip install -r requirements.txt
+
+    - name: Install test dependencies for default python version
+      shell: bash
+      if: steps.test-matrix-present.outputs.matrix-present == 'false'
+      run: |
+        hatch run pip install twine pytest
+
+    - name: Install Requirements.txt Dependencies for test matrix python version
+      shell: bash
+      if: hashFiles('requirements.txt') != '' && steps.cache-restore.outputs.cache-hit != 'true' && failure() && steps.test-matrix-present.outputs.matrix-present == 'true'
+      run: |
+        hatch run hatch-test.py${{ inputs.min-python-version }}:pip install -r requirements.txt
+        hatch run hatch-test.py${{ inputs.max-python-version }}:pip install -r requirements.txt
 
     - name: Cache Hatch Directory
       uses: actions/cache/save@v4

--- a/.github/actions/hatch-setup/action.yml
+++ b/.github/actions/hatch-setup/action.yml
@@ -31,7 +31,7 @@ runs:
         path: |
           ${{ env.HATCH_CACHE_DIR }}
           ${{ env.HATCH_DATA_DIR }}
-        key: ${{ runner.os }}-hatch-${{ hashFiles('pyproject.toml') }}
+        key: ${{ runner.os }}-hatch-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('requirements.txt', '!requirements.txt') }}
 
     - name: Install Dependencies
       shell: bash
@@ -50,6 +50,12 @@ runs:
       run: |
         hatch run python -m pip install twine
 
+    - name: Install Requirements.txt Dependencies
+      shell: bash
+      if: hashFiles('requirements.txt') != '' && steps.cache-restore.outputs.cache-hit != 'true'
+      run: |
+        hatch run pip install -r requirements.txt
+
     - name: Cache Hatch Directory
       uses: actions/cache/save@v4
       if: steps.cache-restore.outputs.cache-hit != 'true'
@@ -58,4 +64,4 @@ runs:
         path: |
           ${{ env.HATCH_CACHE_DIR }}
           ${{ env.HATCH_DATA_DIR }}
-        key: ${{ runner.os }}-hatch-${{ hashFiles('pyproject.toml') }}
+        key: ${{ runner.os }}-hatch-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('requirements.txt', '!requirements.txt') }}

--- a/.github/actions/hatch-setup/action.yml
+++ b/.github/actions/hatch-setup/action.yml
@@ -28,23 +28,23 @@ runs:
       uses: pypa/hatch@install
 
     - name: Restore Hatch Directory
-      uses: actions/cache/restore@v4
-      id: cache-restore
+      uses: actions/cache@v4
+      id: cache
       with:
         path: |
           ${{ env.HATCH_CACHE_DIR }}
           ${{ env.HATCH_DATA_DIR }}
-        key: ${{ runner.os }}-hatch-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('requirements.txt', '!requirements.txt') }}
+        key: ${{ runner.os }}-hatch-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('requirements.txt') }}
 
-    - name: Install Dependencies
+    - name: Install Hatch Python
       shell: bash
-      if: steps.cache-restore.outputs.cache-hit != 'true'
+      if: steps.cache.outputs.cache-hit != 'true'
       run: |
         hatch python install ${{ inputs.min-python-version }} ${{ inputs.max-python-version }}
 
     - name: Install Dependencies
       shell: bash
-      if: steps.cache-restore.outputs.cache-hit != 'true'
+      if: steps.cache.outputs.cache-hit != 'true'
       run: |
         hatch env create
 
@@ -74,7 +74,7 @@ runs:
 
     - name: Install Requirements.txt Dependencies for default python version
       shell: bash
-      if: hashFiles('requirements.txt') != '' && steps.cache-restore.outputs.cache-hit != 'true' && failure() && steps.test-matrix-present.outputs.matrix-present == 'false'
+      if: hashFiles('requirements.txt') != '' && steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'false'
       run: |
         hatch run pip install -r requirements.txt
 
@@ -86,17 +86,7 @@ runs:
 
     - name: Install Requirements.txt Dependencies for test matrix python version
       shell: bash
-      if: hashFiles('requirements.txt') != '' && steps.cache-restore.outputs.cache-hit != 'true' && failure() && steps.test-matrix-present.outputs.matrix-present == 'true'
+      if: hashFiles('requirements.txt') != '' && steps.cache.outputs.cache-hit != 'true' && failure() && steps.test-matrix-present.outputs.matrix-present == 'true'
       run: |
         hatch run hatch-test.py${{ inputs.min-python-version }}:pip install -r requirements.txt
         hatch run hatch-test.py${{ inputs.max-python-version }}:pip install -r requirements.txt
-
-    - name: Cache Hatch Directory
-      uses: actions/cache/save@v4
-      if: steps.cache-restore.outputs.cache-hit != 'true'
-      id: cache-hatch
-      with:
-        path: |
-          ${{ env.HATCH_CACHE_DIR }}
-          ${{ env.HATCH_DATA_DIR }}
-        key: ${{ runner.os }}-hatch-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('requirements.txt', '!requirements.txt') }}

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -23,6 +23,8 @@ on:
 
 permissions:
   id-token: write
+  pull-requests: write
+  checks: write
   contents: write
 
 jobs:
@@ -47,12 +49,23 @@ jobs:
           hatch run hatch-static-analysis:ruff check -o lint.json --output-format json
         shell: bash
 
-      - name: Run Unit Tests
+      - name: Run Unit Tests on Python ${{ inputs.min-python-version }}
         continue-on-error: true
         shell: bash
         run: |
-          hatch test --python ${{ inputs.min-python-version }}  --cover --parallel --junitxml=junit.xml
-          hatch test --python ${{ inputs.max-python-version }}  --cover --parallel --junitxml=junit.xml
+          hatch test --python ${{ inputs.min-python-version }}  --cover --parallel --junitxml=junit-${{ inputs.min-python-version }}.xml
+
+      - name: Run Unit Tests on Python ${{ inputs.max-python-version }}
+        continue-on-error: true
+        shell: bash
+        run: |
+          hatch test --python ${{ inputs.max-python-version }}  --cover --parallel --junitxml=junit-${{ inputs.max-python-version }}.xml
+
+      - name: Report test results
+        uses: mikepenz/action-junit-report@v5
+        if: (hashFiles('junit-*.xml') != '') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        with:
+          report_paths: junit-*.xml
 
       - name: Combine Coverage Reports
         continue-on-error: true

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -54,7 +54,7 @@ jobs:
         shell: bash
         if: steps.hatch-setup.outputs.matrix-present == 'false'
         run: |
-          hatch run pytest --junitxml=junit-default.xml
+          hatch run pytest --cov --junitxml=junit-default.xml
 
       - name: Run Unit Tests on Python ${{ inputs.min-python-version }}
         continue-on-error: true
@@ -70,10 +70,11 @@ jobs:
         run: |
           hatch test --python ${{ inputs.max-python-version }}  --cover --parallel --junitxml=junit-${{ inputs.max-python-version }}.xml
 
-      - name: Report test results
+      - name: Report Test Results
         uses: mikepenz/action-junit-report@v5
         if: (hashFiles('junit-*.xml') != '') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         with:
+          check_name: Unit Test Results
           report_paths: junit-*.xml
 
       - name: Combine Coverage Reports

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -61,14 +61,14 @@ jobs:
         shell: bash
         if: steps.hatch-setup.outputs.matrix-present == 'true'
         run: |
-          hatch test --python ${{ inputs.min-python-version }}  --junitxml=junit-${{ inputs.min-python-version }}.xml
+          hatch test --python ${{ inputs.min-python-version }}  --cover --parallel --junitxml=junit-${{ inputs.min-python-version }}.xml
 
       - name: Run Unit Tests on Python ${{ inputs.max-python-version }}
         continue-on-error: true
         shell: bash
         if: steps.hatch-setup.outputs.matrix-present == 'true'
         run: |
-          hatch test --python ${{ inputs.max-python-version }}  --junitxml=junit-${{ inputs.max-python-version }}.xml
+          hatch test --python ${{ inputs.max-python-version }}  --cover --parallel --junitxml=junit-${{ inputs.max-python-version }}.xml
 
       - name: Report Test Results
         uses: mikepenz/action-junit-report@v5
@@ -76,6 +76,12 @@ jobs:
         with:
           check_name: Unit Test Results
           report_paths: junit-*.xml
+
+      - name: Combine Coverage Reports
+        continue-on-error: true
+        run: |
+          hatch run hatch-test.py${{ inputs.max-python-version }}:coverage combine
+        shell: bash
 
       - name: Report coverage
         continue-on-error: true

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -54,21 +54,21 @@ jobs:
         shell: bash
         if: steps.hatch-setup.outputs.matrix-present == 'false'
         run: |
-          hatch run pytest --cov --junitxml=junit-default.xml
+          hatch run pytest --junitxml=junit-default.xml
 
       - name: Run Unit Tests on Python ${{ inputs.min-python-version }}
         continue-on-error: true
         shell: bash
         if: steps.hatch-setup.outputs.matrix-present == 'true'
         run: |
-          hatch test --python ${{ inputs.min-python-version }}  --cover --parallel --junitxml=junit-${{ inputs.min-python-version }}.xml
+          hatch test --python ${{ inputs.min-python-version }}  --junitxml=junit-${{ inputs.min-python-version }}.xml
 
       - name: Run Unit Tests on Python ${{ inputs.max-python-version }}
         continue-on-error: true
         shell: bash
         if: steps.hatch-setup.outputs.matrix-present == 'true'
         run: |
-          hatch test --python ${{ inputs.max-python-version }}  --cover --parallel --junitxml=junit-${{ inputs.max-python-version }}.xml
+          hatch test --python ${{ inputs.max-python-version }}  --junitxml=junit-${{ inputs.max-python-version }}.xml
 
       - name: Report Test Results
         uses: mikepenz/action-junit-report@v5
@@ -76,12 +76,6 @@ jobs:
         with:
           check_name: Unit Test Results
           report_paths: junit-*.xml
-
-      - name: Combine Coverage Reports
-        continue-on-error: true
-        run: |
-          hatch run hatch-test.py${{ inputs.max-python-version }}:coverage combine
-        shell: bash
 
       - name: Report coverage
         continue-on-error: true
@@ -115,9 +109,12 @@ jobs:
       - name: Test Reports
         if: (hashFiles('junit-*.xml') != '') && (hashFiles('coverage.xml') != '')
         continue-on-error: true
+        env:
+          MIN_PYTHON_VERSION_FILE: ${{ format('junit-{0}.xml', inputs.min-python-version) }}
+          MAX_PYTHON_VERSION_FILE: ${{ format('junit-{0}.xml', inputs.max-python-version) }}
         uses: xportation/junit-coverage-report@main
         with:
-          junit-path: junit-*.xml
+          junit-path: ${{ hashFiles('junit-default.xml') != '' && 'junit-default.xml' || hashFiles(env.MIN_PYTHON_VERSION_FILE) != '' && env.MIN_PYTHON_VERSION_FILE || hashFiles(env.MAX_PYTHON_VERSION_FILE) != '' && env.MAX_PYTHON_VERSION_FILE }}
           coverage-path: coverage.xml
       # Build and verify packages
       - name: Build

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Set up Hatch
         id: hatch-setup
-        uses: SolaceDev/solace-public-workflows/.github/actions/hatch-setup@test
+        uses: SolaceDev/solace-public-workflows/.github/actions/hatch-setup@latest
         with:
           min-python-version: ${{ inputs.min-python-version }}
           max-python-version: ${{ inputs.max-python-version }}

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -38,6 +38,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Hatch
+        id: hatch-setup
         uses: SolaceDev/solace-public-workflows/.github/actions/hatch-setup@test
         with:
           min-python-version: ${{ inputs.min-python-version }}
@@ -49,15 +50,23 @@ jobs:
           hatch run hatch-static-analysis:ruff check -o lint.json --output-format json
         shell: bash
 
+      - name: Run Tests with default python version
+        shell: bash
+        if: steps.hatch-setup.outputs.matrix-present == 'false'
+        run: |
+          hatch run pytest --junitxml=junit-default.xml
+
       - name: Run Unit Tests on Python ${{ inputs.min-python-version }}
         continue-on-error: true
         shell: bash
+        if: steps.hatch-setup.outputs.matrix-present == 'true'
         run: |
           hatch test --python ${{ inputs.min-python-version }}  --cover --parallel --junitxml=junit-${{ inputs.min-python-version }}.xml
 
       - name: Run Unit Tests on Python ${{ inputs.max-python-version }}
         continue-on-error: true
         shell: bash
+        if: steps.hatch-setup.outputs.matrix-present == 'true'
         run: |
           hatch test --python ${{ inputs.max-python-version }}  --cover --parallel --junitxml=junit-${{ inputs.max-python-version }}.xml
 

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -6,7 +6,7 @@ on:
       min-python-version:
         type: string
         required: false
-        default: "3.8"
+        default: "3.9"
         description: "Minimum Python version to test against."
       max-python-version:
         type: string
@@ -112,6 +112,13 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
 
+      - name: Test Reports
+        if: (hashFiles('junit-*.xml') != '') && (hashFiles('coverage.xml') != '')
+        continue-on-error: true
+        uses: xportation/junit-coverage-report@main
+        with:
+          junit-path: junit-*.xml
+          coverage-path: coverage.xml
       # Build and verify packages
       - name: Build
         shell: bash

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Set up Hatch
         id: hatch-setup
-        uses: SolaceDev/solace-public-workflows/.github/actions/hatch-setup@latest
+        uses: SolaceDev/solace-public-workflows/.github/actions/hatch-setup@main
         with:
           min-python-version: ${{ inputs.min-python-version }}
           max-python-version: ${{ inputs.max-python-version }}

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -128,7 +128,7 @@ jobs:
           # A list of JUnit XML files, directories containing the former, and wildcard
           # patterns to process.
           # See @actions/glob for supported patterns.
-          path: junit.xml
+          path: junit-*.xml
 
           # (Optional) Add a summary of the results at the top of the report
           summary: true

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -38,7 +38,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Hatch
-        uses: SolaceDev/solace-public-workflows/.github/actions/hatch-setup@v1.0.0
+        uses: SolaceDev/solace-public-workflows/.github/actions/hatch-setup@test
         with:
           min-python-version: ${{ inputs.min-python-version }}
           max-python-version: ${{ inputs.max-python-version }}

--- a/.github/workflows/hatch_release_pypi.yml
+++ b/.github/workflows/hatch_release_pypi.yml
@@ -40,7 +40,7 @@ jobs:
           ssh-key: ${{ secrets.COMMIT_KEY }}
 
       - name: Set up Hatch
-        uses: SolaceDev/solace-public-workflows/.github/actions/hatch-setup@v1.0.0
+        uses: SolaceDev/solace-public-workflows/.github/actions/hatch-setup@latest
 
       - name: Get Current Version
         run: |

--- a/.github/workflows/hatch_release_pypi.yml
+++ b/.github/workflows/hatch_release_pypi.yml
@@ -40,7 +40,7 @@ jobs:
           ssh-key: ${{ secrets.COMMIT_KEY }}
 
       - name: Set up Hatch
-        uses: SolaceDev/solace-public-workflows/.github/actions/hatch-setup@latest
+        uses: SolaceDev/solace-public-workflows/.github/actions/hatch-setup@main
 
       - name: Get Current Version
         run: |


### PR DESCRIPTION
[DATAGO-88864](https://sol-jira.atlassian.net/browse/DATAGO-88864)

### What is the purpose of this change?

- Imporvements for for setup hatch to make it work better with 2 python versions 
- New pr comment to show test results and coverage on a PR 

![Screenshot 2024-11-20 at 2 16 25 PM](https://github.com/user-attachments/assets/decdd027-e7c2-4a68-ae8a-48e54b439717)


### How is this accomplished?

- Rely on hatch to use pyproject.toml for installing dependencies
- Handle a case where there ios a discrepancy between dependencies in pyproject.toml and requirements.txt files 

Example Run 

https://github.com/SolaceDev/solace-ai-connector/pull/64


[DATAGO-88864]: https://sol-jira.atlassian.net/browse/DATAGO-88864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ