### PR TITLE
DATAGO-88877: Introducing whitesource scan with policy violation checker and vulnerability checker. 

### DIFF
--- a/.github/actions/whitesource-scan/action.yml
+++ b/.github/actions/whitesource-scan/action.yml
@@ -120,7 +120,7 @@ runs:
         echo "scan_duration=${formatted_duration}" >> $GITHUB_ENV
 
     - name: Run Whitesource Project State Checker
-      uses: docker://ghcr.io/solacedev/maas-build-actions:sc_build_actions
+      uses: docker://ghcr.io/solacedev/maas-build-actions:latest
       with:
         entrypoint: /bin/sh
         args: >

--- a/.github/actions/whitesource-scan/action.yml
+++ b/.github/actions/whitesource-scan/action.yml
@@ -1,0 +1,140 @@
+name: WhiteSource Scan
+description: Used for performing WhiteSource scanning.
+
+inputs:
+  whitesource_excludes:
+    description: "Files to exclude from WhiteSource Scan"
+    required: false
+    default: ""
+  target_directory:
+    description: "Directory that contains the JAR files"
+    required: true
+    default: "."
+  language:
+    description: "Language to run WhiteSource Scan against"
+    required: true
+    default: ""
+  whitesource_api_key:
+    description: "API Key for WhiteSource"
+    required: true
+    default: ""
+  whitesource_project_key:
+    description: "Project key for WhiteSource"
+    required: false
+    default: ""
+  whitesource_product_name:
+    description: "Product Name for WhiteSource"
+    required: false
+    default: "maas"
+  whitesource_product_version:
+    description: "Product Version for WhiteSource"
+    required: false
+    default: ""
+  whitesource_project_name:
+    description: "Project Name for WhiteSource"
+    required: false
+    default: ""
+  whitesource_project_version:
+    description: "Project Version for WhiteSource"
+    required: false
+    default: ""
+  whitesource_config_file:
+    description: "Configuration file for WhiteSource"
+    required: false
+    default: ""
+  whitesource_project_state_checker:
+    description: "Poll Mend/Whitesource to be update completed after a scan"
+    required: false
+    default: "true"
+  github_token:
+    description: "GitHub token used for pulling the container image"
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: "WhiteSource Scan"
+      env:
+        unified_agent_url: "https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar"
+        unified_agent_sha_url: "https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar.sha256"
+        WS_APIKEY: ${{ inputs.whitesource_api_key }}
+        WS_PROJECTTOKEN: ${{ inputs.whitesource_project_key }}
+        TARGET_DIR: ${{ inputs.target_directory }}
+        WS_PRODUCTNAME: ${{ inputs.whitesource_product_name }}
+        WS_PRODUCTVERSION: ${{ inputs.whitesource_product_version }}
+        WS_PROJECTNAME: ${{ inputs.whitesource_project_name }}
+        WS_PROJECTVERSION: ${{ inputs.whitesource_project_version }}
+      shell: bash
+      run: |
+        #WS_PROJECTTOKEN takes precedence over a combination of WS_PROJECTNAME and WS_PRODUCTNAME
+        if [[ -n "$WS_PROJECTTOKEN" ]]; then
+            echo "Using WS_PROJECTTOKEN"
+            unset WS_PRODUCTNAME
+            unset WS_PROJECTNAME
+        fi
+        echo """
+        White Source Configuration Variables
+        WS_PRODUCTNAME: $WS_PRODUCTNAME
+        WS_PROJECTNAME: $WS_PROJECTNAME
+        WS_PROJECTTOKEN: $WS_PROJECTTOKEN
+
+        """
+        echo "Set excludes parameter"
+        if [[ ! -z "${{inputs.whitesource_excludes}}" ]]; then
+          export WS_EXCLUDES=${{inputs.whitesource_excludes}}
+          echo "WS_EXCLUDES=$WS_EXCLUDES" >> $GITHUB_ENV
+        fi
+        echo "WS_EXCLUDES: $WS_EXCLUDES"
+        echo "Whitesource- Downloading and verifying latest Agent"
+        if [[ ! -f wss-unified-agent.jar ]]; then
+          curl -LJOs ${{ env.unified_agent_url }}
+        fi
+        sha_from_jar=$(sha256sum  wss-unified-agent.jar | awk '{print $1}')
+        if [[ ! -f wss-unified-agent.jar.sha256 ]]; then
+          curl -LJOs ${{ env.unified_agent_sha_url }}
+        fi        
+        sha_from_file=$(cat wss-unified-agent.jar.sha256 | awk '{print $1}')
+        if [[ "$sha_from_file" == "$sha_from_jar" ]]; then
+            echo "Integrity of the wss-unified-agent.jar file verified .."
+        else
+            echo "Integrity check of wss-unified-agent.jar file failed .."
+            echo "sha_from_jar: $sha_from_jar"
+            echo "sha_from_file: $sha_from_file"
+            exit 1
+        fi
+
+        time_start=$(date +%s)
+        echo "Whitesource- Running scan"
+        if [[ -n "${{ inputs.whitesource_config_file }}" ]]; then
+            echo "Whitesource- Using provided configuration file"
+            java -jar wss-unified-agent.jar -d  ${{ env.TARGET_DIR }} -c  ${{ inputs.whitesource_config_file }} -logLevel Info
+        else
+            echo "Whitesource- Using default configuration file"
+            java -jar wss-unified-agent.jar -d  ${{ env.TARGET_DIR }} -logLevel Info
+        fi
+        time_end=$(date +%s)
+        duration=$((time_end - time_start))
+        formatted_duration=$(date -u -d @${duration} +'%H:%M:%S')
+        echo "scan_start_time=$(date -u -d "@${time_start}" +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_ENV
+        echo "scan_duration=${formatted_duration}" >> $GITHUB_ENV
+
+    - name: Run Whitesource Project State Checker
+      uses: docker://ghcr.io/solacedev/maas-build-actions:sc_build_actions
+      with:
+        entrypoint: /bin/sh
+        args: >
+          -c
+          export GITHUB_ACTION_PATH=/maas-build-actions &&
+          export VIRTUAL_ENV=$GITHUB_ACTION_PATH/venv &&
+          source $VIRTUAL_ENV/bin/activate &&
+          cd actions/whitesource-project-state-checker &&
+          python whitesource_project_state_checker.py
+      env:
+        WS_API_KEY: ${{ inputs.whitesource_api_key }}
+        WS_PROJECT_TOKEN: ${{ inputs.whitesource_project_key }}
+        WS_PRODUCT_NAME: ${{ inputs.whitesource_product_name }}
+        WS_PROJECT_NAME: ${{ inputs.whitesource_project_name }}
+        WS_USER_KEY: ${{ steps.secrets.outputs.WHITESOURCE_USER_KEY }}
+        SCAN_START_TIME: ${{ env.scan_start_time }}
+        GITHUB_TOKEN: ${{ inputs.github_token }}

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -191,8 +191,8 @@ jobs:
           WS_PROJECT_NAME: ${{ inputs.whitesource_project_name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AWS_REGION: ${{ vars.MANIFEST_AWS_REGION }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.MANIFEST_READ_ONLY_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.MANIFEST_READ_ONLY_AWS_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         with:
           entrypoint: /bin/sh
           args: >

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -184,5 +184,5 @@ jobs:
             export GITHUB_ACTION_PATH=/maas-build-actions &&
             export VIRTUAL_ENV=$GITHUB_ACTION_PATH/venv &&
             source $VIRTUAL_ENV/bin/activate &&
-            cd actions/whitesource-vulnerability-checker && python whitesource_vulnurability_checker.py
+            cd /maas-build-actions/actions/whitesource-vulnerability-checker && python whitesource_vulnerability_checker.py
       

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -189,6 +189,8 @@ jobs:
           entrypoint: /bin/sh
           args: >
             -c "
+            export AWS_ACCESS_KEY_ID=${{ secrets.DYNAMODB_MANIFEST_READ_ONLY_AWS_ACCESS_KEY_ID }}
+            export AWS_SECRET_ACCESS_KEY=${{ secrets.DYNAMODB_MANIFEST_READ_ONLY_AWS_SECRET_ACCESS_KEY }}
             export GITHUB_ACTION_PATH=/maas-build-actions &&
             export VIRTUAL_ENV=$GITHUB_ACTION_PATH/venv &&
             source $VIRTUAL_ENV/bin/activate &&

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -199,8 +199,8 @@ jobs:
           args: >
             -c "
             source $VIRTUAL_ENV/bin/activate &&
-            cd $ACTIONS_PATH/whitesource-policy-checker &&
-            python whitesource_policy_checker.py
+            cd $ACTIONS_PATH/whitesource-policy-violation-checker &&
+            python whitesource_policy_violation_checker.py
             "
 
       - name: Run WhiteSource Vulnerability Gate

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -200,8 +200,8 @@ jobs:
           WS_PROJECT_NAME: ${{ inputs.whitesource_project_name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AWS_REGION: ${{ vars.MANIFEST_AWS_REGION }}
-          MANIFEST_AWS_ACCESS_KEY_ID: ${{ secrets.MANIFEST_AWS_ACCESS_KEY_ID }}
-          MANIFEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.MANIFEST_AWS_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.MANIFEST_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.MANIFEST_AWS_SECRET_ACCESS_KEY }}
         with:
           entrypoint: /bin/sh
           args: >
@@ -226,8 +226,8 @@ jobs:
           WS_PROJECT_NAME: ${{ inputs.whitesource_project_name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AWS_REGION: ${{ vars.MANIFEST_AWS_REGION }}
-          MANIFEST_AWS_ACCESS_KEY_ID: ${{ secrets.MANIFEST_AWS_ACCESS_KEY_ID }}
-          MANIFEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.MANIFEST_AWS_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.MANIFEST_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.MANIFEST_AWS_SECRET_ACCESS_KEY }}
           WS_JIRA_CHECK: "False" #No Jira Search for Open Vulnerability Issues
         with:
           entrypoint: /bin/sh

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -165,11 +165,6 @@ jobs:
           ls dist/*.whl | xargs -n1 hatch run python -m twine check
         shell: bash
 
-      - name: Print Debug Info
-        run: |
-          echo "Repository Owner: ${{ github.repository_owner }}"
-          echo "Repository Full Name: ${{ github.event.repository.full_name }}"
-          echo "Repository Name: ${{ github.event.repository.name }}"
 
       - name: Run Whitesource Scan
         if: ${{ github.repository_owner == 'SolaceDev' }}

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -166,14 +166,14 @@ jobs:
       #   shell: bash
 
 
-      - name: Run Whitesource Scan
-        if: ${{ github.repository_owner == 'SolaceDev' }}
-        id: whitesource-scan
-        uses: SolaceDev/solace-public-workflows/.github/actions/whitesource-scan@security_tools
-        with:
-          whitesource_product_name: ${{ inputs.whitesource_product_name }}
-          whitesource_project_name: ${{ inputs.whitesource_project_name }}
-          whitesource_api_key: ${{ secrets.WHITESOURCE_API_KEY }}
+      # - name: Run Whitesource Scan
+      #   if: ${{ github.repository_owner == 'SolaceDev' }}
+      #   id: whitesource-scan
+      #   uses: SolaceDev/solace-public-workflows/.github/actions/whitesource-scan@security_tools
+      #   with:
+      #     whitesource_product_name: ${{ inputs.whitesource_product_name }}
+      #     whitesource_project_name: ${{ inputs.whitesource_project_name }}
+      #     whitesource_api_key: ${{ secrets.WHITESOURCE_API_KEY }}
 
       - name: Run WhiteSource Vulnerability and Policy Gate
         uses: docker://ghcr.io/solacedev/maas-build-actions:latest
@@ -182,7 +182,7 @@ jobs:
           WS_PRODUCT_NAME: ${{ inputs.whitesource_product_name }}
           WS_PROJECT_NAME: ${{ inputs.whitesource_project_name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          AWS_REGION: ${{ vars.AWS_REGION }}
+          AWS_REGION: ${{ vars.MANIFEST_AWS_REGION }}
           AWS_ACCESS_KEY_ID: ${{ secrets.DYNAMODB_MANIFEST_READ_ONLY_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.DYNAMODB_MANIFEST_READ_ONLY_AWS_SECRET_ACCESS_KEY }}
         with:

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -180,9 +180,11 @@ jobs:
         with:
           entrypoint: /bin/sh
           args: >
-            -c
+            -c "
             export GITHUB_ACTION_PATH=/maas-build-actions &&
             export VIRTUAL_ENV=$GITHUB_ACTION_PATH/venv &&
             source $VIRTUAL_ENV/bin/activate &&
-            cd /maas-build-actions/actions/whitesource-vulnerability-checker && python whitesource_vulnerability_checker.py
+            cd /maas-build-actions/actions/whitesource-vulnerability-checker &&
+            python whitesource_vulnerability_checker.py
+            "
       

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -176,7 +176,7 @@ jobs:
           whitesource_api_key: ${{ secrets.WHITESOURCE_API_KEY }}
 
       - name: Run WhiteSource Vulnerability and Policy Gate
-        uses: docker://ghcr.io/solacedev/maas-build-actions:sc_build_actions
+        uses: docker://ghcr.io/solacedev/maas-build-actions:latest
         with:
           entrypoint: /bin/sh
           args: >

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -180,7 +180,7 @@ jobs:
           inputs.whitesource_product_name != '' && 
           inputs.whitesource_project_name != '' 
           }}
-        uses: SolaceDev/solace-public-workflows/.github/actions/whitesource-scan@security_tools
+        uses: SolaceDev/solace-public-workflows/.github/actions/whitesource-scan@main
         with:
           whitesource_product_name: ${{ inputs.whitesource_product_name }}
           whitesource_project_name: ${{ inputs.whitesource_project_name }}
@@ -193,7 +193,7 @@ jobs:
           inputs.whitesource_project_name != '' && 
           github.ref == 'refs/heads/main' 
           }}
-        uses: docker://ghcr.io/solacedev/maas-build-actions:ws_policy_checker_image
+        uses: docker://ghcr.io/solacedev/maas-build-actions:latest
         env:
           WS_API_KEY: ${{ secrets.WHITESOURCE_API_KEY }}
           WS_PRODUCT_NAME: ${{ inputs.whitesource_product_name }}
@@ -218,7 +218,7 @@ jobs:
           inputs.whitesource_project_name != '' && 
           github.ref == 'refs/heads/main' 
           }}
-        uses: docker://ghcr.io/solacedev/maas-build-actions:ws_policy_checker_image
+        uses: docker://ghcr.io/solacedev/maas-build-actions:latest
         continue-on-error: true
         env:
           WS_API_KEY: ${{ secrets.WHITESOURCE_API_KEY }}

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -194,7 +194,7 @@ jobs:
           AWS_REGION: ${{ vars.MANIFEST_AWS_REGION }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          WS_JIRA_CHECK: False #No Jira Search for Open Vulnerability Issues
+          WS_JIRA_CHECK: "False" #No Jira Search for Open Vulnerability Issues
           ACTIONS_PATH: /maas-build-actions/actions
           VIRTUAL_ENV: /maas-build-actions/venv
         with:

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -174,7 +174,6 @@ jobs:
           ls dist/*.whl | xargs -n1 hatch run python -m twine check
         shell: bash
 
-
       - name: Run Whitesource Scan
         if: ${{ github.repository_owner == 'SolaceDev' }}
         id: whitesource-scan
@@ -222,5 +221,3 @@ jobs:
             cd $ACTIONS_PATH/whitesource-vulnerability-checker &&
             python whitesource_vulnerability_checker.py
             "
-
-          

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -185,7 +185,6 @@ jobs:
       #     whitesource_api_key: ${{ secrets.WHITESOURCE_API_KEY }}
 
       - name: Run WhiteSource Vulnerability Gate
-        continue-on-error: true
         uses: docker://ghcr.io/solacedev/maas-build-actions:latest
         env:
           WS_API_KEY: ${{ secrets.WHITESOURCE_API_KEY }}
@@ -208,7 +207,6 @@ jobs:
             "
         
       - name: Run WhiteSource Policy Gate
-        continue-on-error: true
         uses: docker://ghcr.io/solacedev/maas-build-actions:latest
         env:
           WS_API_KEY: ${{ secrets.WHITESOURCE_API_KEY }}

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -184,7 +184,7 @@ jobs:
           whitesource_api_key: ${{ secrets.WHITESOURCE_API_KEY }}
 
       - name: Run WhiteSource Policy Gate
-        uses: docker://ghcr.io/solacedev/maas-build-actions:security_tools
+        uses: docker://ghcr.io/solacedev/maas-build-actions:latest
         env:
           WS_API_KEY: ${{ secrets.WHITESOURCE_API_KEY }}
           WS_PRODUCT_NAME: ${{ inputs.whitesource_product_name }}
@@ -203,7 +203,7 @@ jobs:
             "
 
       - name: Run WhiteSource Vulnerability Gate
-        uses: docker://ghcr.io/solacedev/maas-build-actions:security_tools
+        uses: docker://ghcr.io/solacedev/maas-build-actions:latest
         continue-on-error: true
         env:
           WS_API_KEY: ${{ secrets.WHITESOURCE_API_KEY }}

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -37,10 +37,10 @@ on:
       PRISMA_SECRET_ACCESS_KEY:
         description: "Prisma Secret Access Key"
         required: false
-      AWS_ACCESS_KEY_ID:
+      MANIFEST_AWS_ACCESS_KEY_ID:
         description: "AWS Access Key ID"
         required: false
-      AWS_SECRET_ACCESS_KEY:
+      MANIFEST_AWS_SECRET_ACCESS_KEY:
         description: "AWS Secret Access Key"
         required: false
 
@@ -200,8 +200,8 @@ jobs:
           WS_PROJECT_NAME: ${{ inputs.whitesource_project_name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AWS_REGION: ${{ vars.MANIFEST_AWS_REGION }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          MANIFEST_AWS_ACCESS_KEY_ID: ${{ secrets.MANIFEST_AWS_ACCESS_KEY_ID }}
+          MANIFEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.MANIFEST_AWS_SECRET_ACCESS_KEY }}
         with:
           entrypoint: /bin/sh
           args: >
@@ -226,8 +226,8 @@ jobs:
           WS_PROJECT_NAME: ${{ inputs.whitesource_project_name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AWS_REGION: ${{ vars.MANIFEST_AWS_REGION }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          MANIFEST_AWS_ACCESS_KEY_ID: ${{ secrets.MANIFEST_AWS_ACCESS_KEY_ID }}
+          MANIFEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.MANIFEST_AWS_SECRET_ACCESS_KEY }}
           WS_JIRA_CHECK: "False" #No Jira Search for Open Vulnerability Issues
         with:
           entrypoint: /bin/sh

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -195,13 +195,11 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         with:
-          entrypoint: /bin/sh
           args: >
-            -c "
             . $VIRTUAL_ENV/bin/activate &&
             cd $ACTIONS_PATH/whitesource-policy-violation-checker &&
             python whitesource_policy_violation_checker.py
-            "
+            
 
       - name: Run WhiteSource Vulnerability Gate
         uses: docker://ghcr.io/solacedev/maas-build-actions:ws_policy_checker_image
@@ -216,10 +214,10 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           WS_JIRA_CHECK: "False" #No Jira Search for Open Vulnerability Issues
         with:
-          entrypoint: /bin/sh
           args: >
             . $VIRTUAL_ENV/bin/activate &&
             cd $ACTIONS_PATH/whitesource-vulnerability-checker &&
             python whitesource_vulnerability_checker.py
+            
 
           

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -177,7 +177,7 @@ jobs:
       - name: Run Whitesource Scan
         if: ${{ github.repository_owner == 'SolaceDev' }}
         id: whitesource-scan
-        uses: SolaceDev/solace-public-workflows/.github/actions/whitesource-scan@main
+        uses: SolaceDev/solace-public-workflows/.github/actions/whitesource-scan@security_tools
         with:
           whitesource_product_name: ${{ inputs.whitesource_product_name }}
           whitesource_project_name: ${{ inputs.whitesource_project_name }}

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -195,8 +195,11 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         with:
-          entrypoint: /bin/sh -c
-          args: ". $VIRTUAL_ENV/bin/activate && cd $ACTIONS_PATH/whitesource-policy-violation-checker && python whitesource_policy_violation_checker.py"
+          entrypoint: /bin/sh
+          args: >
+            "-c . $VIRTUAL_ENV/bin/activate && \
+             cd $ACTIONS_PATH/whitesource-policy-violation-checker && \
+             python whitesource_policy_violation_checker.py"
 
       - name: Run WhiteSource Vulnerability Gate
         uses: docker://ghcr.io/solacedev/maas-build-actions:ws_policy_checker_image
@@ -211,7 +214,10 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           WS_JIRA_CHECK: "False" #No Jira Search for Open Vulnerability Issues
         with:
-          entrypoint: /bin/sh -c
-          args: ". $VIRTUAL_ENV/bin/activate && cd $ACTIONS_PATH/whitesource-vulnerability-checker && python whitesource_vulnerability_checker.py"
+          entrypoint: /bin/sh
+          args: >
+            "-c . $VIRTUAL_ENV/bin/activate && \
+            cd $ACTIONS_PATH/whitesource-vulnerability-checker && \
+            python whitesource_vulnerability_checker.py"
 
           

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -186,6 +186,7 @@ jobs:
 
       - name: Run WhiteSource Vulnerability Gate
         uses: docker://ghcr.io/solacedev/maas-build-actions:latest
+        continue-on-error: true
         env:
           WS_API_KEY: ${{ secrets.WHITESOURCE_API_KEY }}
           WS_PRODUCT_NAME: ${{ inputs.whitesource_product_name }}

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -184,7 +184,7 @@ jobs:
       #     whitesource_project_name: ${{ inputs.whitesource_project_name }}
       #     whitesource_api_key: ${{ secrets.WHITESOURCE_API_KEY }}
 
-      - name: Run WhiteSource Vulnerability and Policy Gate
+      - name: Run WhiteSource Vulnerability Gate
         continue-on-error: true
         uses: docker://ghcr.io/solacedev/maas-build-actions:latest
         env:

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -195,11 +195,13 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         with:
+          entrypoint: /bin/sh
           args: >
+            -c "
             . $VIRTUAL_ENV/bin/activate &&
             cd $ACTIONS_PATH/whitesource-policy-violation-checker &&
             python whitesource_policy_violation_checker.py
-            
+            "
 
       - name: Run WhiteSource Vulnerability Gate
         uses: docker://ghcr.io/solacedev/maas-build-actions:ws_policy_checker_image
@@ -214,10 +216,11 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           WS_JIRA_CHECK: "False" #No Jira Search for Open Vulnerability Issues
         with:
+          entrypoint: /bin/sh
           args: >
-            . $VIRTUAL_ENV/bin/activate &&
+            -c ". $VIRTUAL_ENV/bin/activate &&
             cd $ACTIONS_PATH/whitesource-vulnerability-checker &&
             python whitesource_vulnerability_checker.py
-            
+            "
 
           

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -184,7 +184,7 @@ jobs:
           whitesource_api_key: ${{ secrets.WHITESOURCE_API_KEY }}
 
       - name: Run WhiteSource Policy Gate
-        uses: docker://ghcr.io/solacedev/maas-build-actions:latest
+        uses: docker://ghcr.io/solacedev/maas-build-actions:ws_policy_checker_image
         env:
           WS_API_KEY: ${{ secrets.WHITESOURCE_API_KEY }}
           WS_PRODUCT_NAME: ${{ inputs.whitesource_product_name }}
@@ -203,7 +203,7 @@ jobs:
             "
 
       - name: Run WhiteSource Vulnerability Gate
-        uses: docker://ghcr.io/solacedev/maas-build-actions:latest
+        uses: docker://ghcr.io/solacedev/maas-build-actions:ws_policy_checker_image
         continue-on-error: true
         env:
           WS_API_KEY: ${{ secrets.WHITESOURCE_API_KEY }}

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -195,19 +195,37 @@ jobs:
           AWS_REGION: ${{ vars.MANIFEST_AWS_REGION }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          WS_JIRA_CHECK: False #No Jira Search for Open Vulnerability Issues
+          ACTIONS_PATH: /maas-build-actions/actions
+          VIRTUAL_ENV: /maas-build-actions/venv
         with:
           entrypoint: /bin/sh
           args: >
             -c "
-            export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
-            export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
-            export GITHUB_ACTION_PATH=/maas-build-actions &&
-            export VIRTUAL_ENV=$GITHUB_ACTION_PATH/venv &&
             source $VIRTUAL_ENV/bin/activate &&
-            export WS_JIRA_CHECK='False' &&
-            cd /maas-build-actions/actions/whitesource-vulnerability-checker &&
-            python whitesource_vulnerability_checker.py &&
-            cd /maas-build-actions/actions/whitesource-policy-checker &&
+            cd $ACTIONS_PATH/whitesource-vulnerability-checker &&
+            python whitesource_vulnerability_checker.py
+            "
+        
+      - name: Run WhiteSource Policy Gate
+        continue-on-error: true
+        uses: docker://ghcr.io/solacedev/maas-build-actions:latest
+        env:
+          WS_API_KEY: ${{ secrets.WHITESOURCE_API_KEY }}
+          WS_PRODUCT_NAME: ${{ inputs.whitesource_product_name }}
+          WS_PROJECT_NAME: ${{ inputs.whitesource_project_name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AWS_REGION: ${{ vars.MANIFEST_AWS_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          ACTIONS_PATH: /maas-build-actions/actions
+          VIRUTAL_ENV: /maas-build-actions/venv
+        with:
+          entrypoint: /bin/sh
+          args: >
+            -c "
+            source $VIRTUAL_ENV/bin/activate &&
+            cd $ACTIONS_PATH/whitesource-policy-checker &&
             python whitesource_policy_checker.py
             "
-      
+          

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -69,123 +69,123 @@ jobs:
           min-python-version: ${{ inputs.min-python-version }}
           max-python-version: ${{ inputs.max-python-version }}
 
-      # - name: Run Lint
-      #   continue-on-error: true
-      #   run: |
-      #     hatch run hatch-static-analysis:ruff check -o lint.json --output-format json
-      #   shell: bash
+      - name: Run Lint
+        continue-on-error: true
+        run: |
+          hatch run hatch-static-analysis:ruff check -o lint.json --output-format json
+        shell: bash
 
-      # - name: Run Tests with default python version
-      #   shell: bash
-      #   if: steps.hatch-setup.outputs.matrix-present == 'false'
-      #   run: |
-      #     hatch run pytest --junitxml=junit-default.xml
+      - name: Run Tests with default python version
+        shell: bash
+        if: steps.hatch-setup.outputs.matrix-present == 'false'
+        run: |
+          hatch run pytest --junitxml=junit-default.xml
 
-      # - name: Run Unit Tests on Python ${{ inputs.min-python-version }}
-      #   continue-on-error: true
-      #   shell: bash
-      #   if: steps.hatch-setup.outputs.matrix-present == 'true'
-      #   run: |
-      #     hatch test --python ${{ inputs.min-python-version }}  --cover --parallel --junitxml=junit-${{ inputs.min-python-version }}.xml
+      - name: Run Unit Tests on Python ${{ inputs.min-python-version }}
+        continue-on-error: true
+        shell: bash
+        if: steps.hatch-setup.outputs.matrix-present == 'true'
+        run: |
+          hatch test --python ${{ inputs.min-python-version }}  --cover --parallel --junitxml=junit-${{ inputs.min-python-version }}.xml
 
-      # - name: Run Unit Tests on Python ${{ inputs.max-python-version }}
-      #   continue-on-error: true
-      #   shell: bash
-      #   if: steps.hatch-setup.outputs.matrix-present == 'true'
-      #   run: |
-      #     hatch test --python ${{ inputs.max-python-version }}  --cover --parallel --junitxml=junit-${{ inputs.max-python-version }}.xml
+      - name: Run Unit Tests on Python ${{ inputs.max-python-version }}
+        continue-on-error: true
+        shell: bash
+        if: steps.hatch-setup.outputs.matrix-present == 'true'
+        run: |
+          hatch test --python ${{ inputs.max-python-version }}  --cover --parallel --junitxml=junit-${{ inputs.max-python-version }}.xml
 
-      # - name: Status Check - Unit Tests on default python version
-      #   uses: mikepenz/action-junit-report@v5
-      #   if: hashFiles('junit-default.xml') != ''
-      #   with:
-      #     check_name: Unit Tests on default python version
-      #     report_paths: junit-default.xml
+      - name: Status Check - Unit Tests on default python version
+        uses: mikepenz/action-junit-report@v5
+        if: hashFiles('junit-default.xml') != ''
+        with:
+          check_name: Unit Tests on default python version
+          report_paths: junit-default.xml
 
-      # - name: Status Check - Unit Tests on Python ${{ inputs.min-python-version }}
-      #   uses: mikepenz/action-junit-report@v5
-      #   if: hashFiles('junit-${{ inputs.min-python-version }}.xml') != ''
-      #   with:
-      #     check_name: Unit Tests on Python ${{ inputs.min-python-version }}
-      #     report_paths: junit-${{ inputs.min-python-version }}.xml
+      - name: Status Check - Unit Tests on Python ${{ inputs.min-python-version }}
+        uses: mikepenz/action-junit-report@v5
+        if: hashFiles('junit-${{ inputs.min-python-version }}.xml') != ''
+        with:
+          check_name: Unit Tests on Python ${{ inputs.min-python-version }}
+          report_paths: junit-${{ inputs.min-python-version }}.xml
 
-      # - name: Status Check - Unit Tests on Python ${{ inputs.max-python-version }}
-      #   uses: mikepenz/action-junit-report@v5
-      #   if: hashFiles('junit-${{ inputs.max-python-version }}.xml') != ''
-      #   with:
-      #     check_name: Unit Tests on Python ${{ inputs.max-python-version }}
-      #     report_paths: junit-${{ inputs.max-python-version }}.xml
+      - name: Status Check - Unit Tests on Python ${{ inputs.max-python-version }}
+        uses: mikepenz/action-junit-report@v5
+        if: hashFiles('junit-${{ inputs.max-python-version }}.xml') != ''
+        with:
+          check_name: Unit Tests on Python ${{ inputs.max-python-version }}
+          report_paths: junit-${{ inputs.max-python-version }}.xml
 
-      # - name: Combine Coverage Reports
-      #   continue-on-error: true
-      #   if: hashFiles('*.cov') != ''
-      #   run: |
-      #     hatch run hatch-test.py${{ inputs.max-python-version }}:coverage combine
-      #   shell: bash
+      - name: Combine Coverage Reports
+        continue-on-error: true
+        if: hashFiles('*.cov') != ''
+        run: |
+          hatch run hatch-test.py${{ inputs.max-python-version }}:coverage combine
+        shell: bash
 
-      # - name: Report coverage
-      #   continue-on-error: true
-      #   if: hashFiles('*.cov') != ''
-      #   run: |
-      #     hatch run hatch-test.py${{ inputs.max-python-version }}:coverage xml
-      #   shell: bash
+      - name: Report coverage
+        continue-on-error: true
+        if: hashFiles('*.cov') != ''
+        run: |
+          hatch run hatch-test.py${{ inputs.max-python-version }}:coverage xml
+        shell: bash
 
-      # - name: SonarQube Scan
-      #   if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
-      #   uses: sonarsource/sonarqube-scan-action@v2.2.0
-      #   env:
-      #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      #     SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-      #   with:
-      #     args: >
-      #       -Dsonar.tests=tests/
-      #       -Dsonar.verbose=true
-      #       -Dsonar.sources=src/
-      #       -Dsonar.projectKey=${{github.repository_owner}}_${{github.event.repository.name}}
-      #       -Dsonar.python.coverage.reportPaths=coverage.xml
-      #       -Dsonar.python.ruff.reportPaths=lint.json
+      - name: SonarQube Scan
+        if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+        uses: sonarsource/sonarqube-scan-action@v2.2.0
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+        with:
+          args: >
+            -Dsonar.tests=tests/
+            -Dsonar.verbose=true
+            -Dsonar.sources=src/
+            -Dsonar.projectKey=${{github.repository_owner}}_${{github.event.repository.name}}
+            -Dsonar.python.coverage.reportPaths=coverage.xml
+            -Dsonar.python.ruff.reportPaths=lint.json
 
-      # - name: SonarQube Quality Gate check
-      #   if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-      #   id: sonarqube-quality-gate-check
-      #   uses: sonarsource/sonarqube-quality-gate-action@master
-      #   env:
-      #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      #     SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+      - name: SonarQube Quality Gate check
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        id: sonarqube-quality-gate-check
+        uses: sonarsource/sonarqube-quality-gate-action@master
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
 
-      # - name: Comment on PR with Test Results
-      #   if: (hashFiles('junit-*.xml') != '') && (hashFiles('coverage.xml') != '')
-      #   continue-on-error: true
-      #   env:
-      #     MIN_PYTHON_VERSION_FILE: ${{ format('junit-{0}.xml', inputs.min-python-version) }}
-      #     MAX_PYTHON_VERSION_FILE: ${{ format('junit-{0}.xml', inputs.max-python-version) }}
-      #   uses: xportation/junit-coverage-report@main
-      #   with:
-      #     junit-path: ${{ hashFiles('junit-default.xml') != '' && 'junit-default.xml' || hashFiles(env.MIN_PYTHON_VERSION_FILE) != '' && env.MIN_PYTHON_VERSION_FILE || hashFiles(env.MAX_PYTHON_VERSION_FILE) != '' && env.MAX_PYTHON_VERSION_FILE }}
-      #     coverage-path: coverage.xml
+      - name: Comment on PR with Test Results
+        if: (hashFiles('junit-*.xml') != '') && (hashFiles('coverage.xml') != '')
+        continue-on-error: true
+        env:
+          MIN_PYTHON_VERSION_FILE: ${{ format('junit-{0}.xml', inputs.min-python-version) }}
+          MAX_PYTHON_VERSION_FILE: ${{ format('junit-{0}.xml', inputs.max-python-version) }}
+        uses: xportation/junit-coverage-report@main
+        with:
+          junit-path: ${{ hashFiles('junit-default.xml') != '' && 'junit-default.xml' || hashFiles(env.MIN_PYTHON_VERSION_FILE) != '' && env.MIN_PYTHON_VERSION_FILE || hashFiles(env.MAX_PYTHON_VERSION_FILE) != '' && env.MAX_PYTHON_VERSION_FILE }}
+          coverage-path: coverage.xml
 
       - name: Build
         shell: bash
         run: hatch build
 
-      # - name: Verify Packages
-      #   run: |
-      #     ls dist/*.tar.gz | xargs -n1 hatch run python -m twine check
-      #     ls dist/*.whl | xargs -n1 hatch run python -m twine check
-      #   shell: bash
+      - name: Verify Packages
+        run: |
+          ls dist/*.tar.gz | xargs -n1 hatch run python -m twine check
+          ls dist/*.whl | xargs -n1 hatch run python -m twine check
+        shell: bash
 
 
-      # - name: Run Whitesource Scan
-      #   if: ${{ github.repository_owner == 'SolaceDev' }}
-      #   id: whitesource-scan
-      #   uses: SolaceDev/solace-public-workflows/.github/actions/whitesource-scan@security_tools
-      #   with:
-      #     whitesource_product_name: ${{ inputs.whitesource_product_name }}
-      #     whitesource_project_name: ${{ inputs.whitesource_project_name }}
-      #     whitesource_api_key: ${{ secrets.WHITESOURCE_API_KEY }}
+      - name: Run Whitesource Scan
+        if: ${{ github.repository_owner == 'SolaceDev' }}
+        id: whitesource-scan
+        uses: SolaceDev/solace-public-workflows/.github/actions/whitesource-scan@main
+        with:
+          whitesource_product_name: ${{ inputs.whitesource_product_name }}
+          whitesource_project_name: ${{ inputs.whitesource_project_name }}
+          whitesource_api_key: ${{ secrets.WHITESOURCE_API_KEY }}
 
       - name: Run WhiteSource Policy Gate
-        uses: docker://ghcr.io/solacedev/maas-build-actions:ws_policy_checker_image
+        uses: docker://ghcr.io/solacedev/maas-build-actions:latest
         env:
           WS_API_KEY: ${{ secrets.WHITESOURCE_API_KEY }}
           WS_PRODUCT_NAME: ${{ inputs.whitesource_product_name }}
@@ -204,7 +204,7 @@ jobs:
             "
 
       - name: Run WhiteSource Vulnerability Gate
-        uses: docker://ghcr.io/solacedev/maas-build-actions:ws_policy_checker_image
+        uses: docker://ghcr.io/solacedev/maas-build-actions:latest
         continue-on-error: true
         env:
           WS_API_KEY: ${{ secrets.WHITESOURCE_API_KEY }}

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -35,7 +35,16 @@ on:
         description: "Prisma Access key ID"
         required: false
       PRISMA_SECRET_ACCESS_KEY:
+        description: "Prisma Secret Access Key"
         required: false
+      AWS_ACCESS_KEY_ID:
+        description: "AWS Access Key ID"
+        required: false
+      AWS_SECRET_ACCESS_KEY:
+        description: "AWS Secret Access Key"
+        required: false
+
+
 
 permissions:
   id-token: write

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -185,7 +185,7 @@ jobs:
       #     whitesource_api_key: ${{ secrets.WHITESOURCE_API_KEY }}
 
       - name: Run WhiteSource Policy Gate
-        uses: docker://ghcr.io/solacedev/maas-build-actions:latest
+        uses: docker://ghcr.io/solacedev/maas-build-actions:ws_policy_checker_image
         env:
           WS_API_KEY: ${{ secrets.WHITESOURCE_API_KEY }}
           WS_PRODUCT_NAME: ${{ inputs.whitesource_product_name }}
@@ -194,8 +194,6 @@ jobs:
           AWS_REGION: ${{ vars.MANIFEST_AWS_REGION }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          ACTIONS_PATH: /maas-build-actions/actions
-          VIRTUAL_ENV: /maas-build-actions/venv
         with:
           entrypoint: /bin/sh
           args: >
@@ -206,7 +204,7 @@ jobs:
             "
 
       - name: Run WhiteSource Vulnerability Gate
-        uses: docker://ghcr.io/solacedev/maas-build-actions:latest
+        uses: docker://ghcr.io/solacedev/maas-build-actions:ws_policy_checker_image
         continue-on-error: true
         env:
           WS_API_KEY: ${{ secrets.WHITESOURCE_API_KEY }}
@@ -217,12 +215,9 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           WS_JIRA_CHECK: "False" #No Jira Search for Open Vulnerability Issues
-          ACTIONS_PATH: /maas-build-actions/actions
-          VIRTUAL_ENV: /maas-build-actions/venv
         with:
           entrypoint: /bin/sh
           args: >
-            -c "
             source $VIRTUAL_ENV/bin/activate &&
             cd $ACTIONS_PATH/whitesource-vulnerability-checker &&
             python whitesource_vulnerability_checker.py

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -175,8 +175,7 @@ jobs:
         shell: bash
 
       - name: Run Whitesource Scan
-        if: ${{ github.repository_owner == 'SolaceDev' }}
-        id: whitesource-scan
+        if: ${{ github.repository_owner == 'SolaceDev' && inputs.whitesource_product_name != '' && inputs.whitesource_project_name != '' }}
         uses: SolaceDev/solace-public-workflows/.github/actions/whitesource-scan@security_tools
         with:
           whitesource_product_name: ${{ inputs.whitesource_product_name }}
@@ -184,6 +183,7 @@ jobs:
           whitesource_api_key: ${{ secrets.WHITESOURCE_API_KEY }}
 
       - name: Run WhiteSource Policy Gate
+        if: ${{ github.repository_owner == 'SolaceDev' && inputs.whitesource_product_name && inputs.whitesource_project_name && github.ref == 'refs/heads/main' }}
         uses: docker://ghcr.io/solacedev/maas-build-actions:ws_policy_checker_image
         env:
           WS_API_KEY: ${{ secrets.WHITESOURCE_API_KEY }}
@@ -203,6 +203,7 @@ jobs:
             "
 
       - name: Run WhiteSource Vulnerability Gate
+        if: ${{ github.repository_owner == 'SolaceDev' && inputs.whitesource_product_name && inputs.whitesource_project_name && github.ref == 'refs/heads/main' }}
         uses: docker://ghcr.io/solacedev/maas-build-actions:ws_policy_checker_image
         continue-on-error: true
         env:

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -184,15 +184,15 @@ jobs:
           whitesource_api_key: ${{ secrets.WHITESOURCE_API_KEY }}
 
       - name: Run WhiteSource Policy Gate
-        uses: docker://ghcr.io/solacedev/maas-build-actions:latest
+        uses: docker://ghcr.io/solacedev/maas-build-actions:security_tools
         env:
           WS_API_KEY: ${{ secrets.WHITESOURCE_API_KEY }}
           WS_PRODUCT_NAME: ${{ inputs.whitesource_product_name }}
           WS_PROJECT_NAME: ${{ inputs.whitesource_project_name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AWS_REGION: ${{ vars.MANIFEST_AWS_REGION }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.MANIFEST_READ_ONLY_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.MANIFEST_READ_ONLY_AWS_SECRET_ACCESS_KEY }}
         with:
           entrypoint: /bin/sh
           args: >
@@ -203,7 +203,7 @@ jobs:
             "
 
       - name: Run WhiteSource Vulnerability Gate
-        uses: docker://ghcr.io/solacedev/maas-build-actions:latest
+        uses: docker://ghcr.io/solacedev/maas-build-actions:security_tools
         continue-on-error: true
         env:
           WS_API_KEY: ${{ secrets.WHITESOURCE_API_KEY }}

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -191,7 +191,7 @@ jobs:
           WS_PRODUCT_NAME: ${{ inputs.whitesource_product_name }}
           WS_PROJECT_NAME: ${{ inputs.whitesource_project_name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_REGION: ${{ vars.MANIFEST_AWS_REGION }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         with:
@@ -211,7 +211,7 @@ jobs:
           WS_PRODUCT_NAME: ${{ inputs.whitesource_product_name }}
           WS_PROJECT_NAME: ${{ inputs.whitesource_project_name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_REGION: ${{ vars.MANIFEST_AWS_REGION }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           WS_JIRA_CHECK: "False" #No Jira Search for Open Vulnerability Issues

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -197,9 +197,11 @@ jobs:
         with:
           entrypoint: /bin/sh
           args: >
-            "-c . $VIRTUAL_ENV/bin/activate && \
-             cd $ACTIONS_PATH/whitesource-policy-violation-checker && \
-             python whitesource_policy_violation_checker.py"
+            -c "
+            . $VIRTUAL_ENV/bin/activate &&
+            cd $ACTIONS_PATH/whitesource-policy-violation-checker &&
+            python whitesource_policy_violation_checker.py
+            "
 
       - name: Run WhiteSource Vulnerability Gate
         uses: docker://ghcr.io/solacedev/maas-build-actions:ws_policy_checker_image
@@ -216,8 +218,9 @@ jobs:
         with:
           entrypoint: /bin/sh
           args: >
-            "-c . $VIRTUAL_ENV/bin/activate && \
-            cd $ACTIONS_PATH/whitesource-vulnerability-checker && \
-            python whitesource_vulnerability_checker.py"
+            -c ". $VIRTUAL_ENV/bin/activate &&
+            cd $ACTIONS_PATH/whitesource-vulnerability-checker &&
+            python whitesource_vulnerability_checker.py
+            "
 
           

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -185,6 +185,7 @@ jobs:
       #     whitesource_api_key: ${{ secrets.WHITESOURCE_API_KEY }}
 
       - name: Run WhiteSource Vulnerability and Policy Gate
+        continue-on-error: true
         uses: docker://ghcr.io/solacedev/maas-build-actions:latest
         env:
           WS_API_KEY: ${{ secrets.WHITESOURCE_API_KEY }}
@@ -203,7 +204,10 @@ jobs:
             export GITHUB_ACTION_PATH=/maas-build-actions &&
             export VIRTUAL_ENV=$GITHUB_ACTION_PATH/venv &&
             source $VIRTUAL_ENV/bin/activate &&
+            export WS_JIRA_CHECK='False' &&
             cd /maas-build-actions/actions/whitesource-vulnerability-checker &&
-            python whitesource_vulnerability_checker.py
+            python whitesource_vulnerability_checker.py &&
+            cd /maas-build-actions/actions/whitesource-policy-checker &&
+            python whitesource_policy_checker.py
             "
       

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -195,7 +195,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           ACTIONS_PATH: /maas-build-actions/actions
-          VIRUTAL_ENV: /maas-build-actions/venv
+          VIRTUAL_ENV: /maas-build-actions/venv
         with:
           entrypoint: /bin/sh
           args: >
@@ -203,7 +203,7 @@ jobs:
             source $VIRTUAL_ENV/bin/activate &&
             cd $ACTIONS_PATH/whitesource-policy-checker &&
             python whitesource_policy_checker.py
-          "
+            "
 
       - name: Run WhiteSource Vulnerability Gate
         uses: docker://ghcr.io/solacedev/maas-build-actions:latest

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -60,110 +60,110 @@ jobs:
           min-python-version: ${{ inputs.min-python-version }}
           max-python-version: ${{ inputs.max-python-version }}
 
-      - name: Run Lint
-        continue-on-error: true
-        run: |
-          hatch run hatch-static-analysis:ruff check -o lint.json --output-format json
-        shell: bash
+      # - name: Run Lint
+      #   continue-on-error: true
+      #   run: |
+      #     hatch run hatch-static-analysis:ruff check -o lint.json --output-format json
+      #   shell: bash
 
-      - name: Run Tests with default python version
-        shell: bash
-        if: steps.hatch-setup.outputs.matrix-present == 'false'
-        run: |
-          hatch run pytest --junitxml=junit-default.xml
+      # - name: Run Tests with default python version
+      #   shell: bash
+      #   if: steps.hatch-setup.outputs.matrix-present == 'false'
+      #   run: |
+      #     hatch run pytest --junitxml=junit-default.xml
 
-      - name: Run Unit Tests on Python ${{ inputs.min-python-version }}
-        continue-on-error: true
-        shell: bash
-        if: steps.hatch-setup.outputs.matrix-present == 'true'
-        run: |
-          hatch test --python ${{ inputs.min-python-version }}  --cover --parallel --junitxml=junit-${{ inputs.min-python-version }}.xml
+      # - name: Run Unit Tests on Python ${{ inputs.min-python-version }}
+      #   continue-on-error: true
+      #   shell: bash
+      #   if: steps.hatch-setup.outputs.matrix-present == 'true'
+      #   run: |
+      #     hatch test --python ${{ inputs.min-python-version }}  --cover --parallel --junitxml=junit-${{ inputs.min-python-version }}.xml
 
-      - name: Run Unit Tests on Python ${{ inputs.max-python-version }}
-        continue-on-error: true
-        shell: bash
-        if: steps.hatch-setup.outputs.matrix-present == 'true'
-        run: |
-          hatch test --python ${{ inputs.max-python-version }}  --cover --parallel --junitxml=junit-${{ inputs.max-python-version }}.xml
+      # - name: Run Unit Tests on Python ${{ inputs.max-python-version }}
+      #   continue-on-error: true
+      #   shell: bash
+      #   if: steps.hatch-setup.outputs.matrix-present == 'true'
+      #   run: |
+      #     hatch test --python ${{ inputs.max-python-version }}  --cover --parallel --junitxml=junit-${{ inputs.max-python-version }}.xml
 
-      - name: Status Check - Unit Tests on default python version
-        uses: mikepenz/action-junit-report@v5
-        if: hashFiles('junit-default.xml') != ''
-        with:
-          check_name: Unit Tests on default python version
-          report_paths: junit-default.xml
+      # - name: Status Check - Unit Tests on default python version
+      #   uses: mikepenz/action-junit-report@v5
+      #   if: hashFiles('junit-default.xml') != ''
+      #   with:
+      #     check_name: Unit Tests on default python version
+      #     report_paths: junit-default.xml
 
-      - name: Status Check - Unit Tests on Python ${{ inputs.min-python-version }}
-        uses: mikepenz/action-junit-report@v5
-        if: hashFiles('junit-${{ inputs.min-python-version }}.xml') != ''
-        with:
-          check_name: Unit Tests on Python ${{ inputs.min-python-version }}
-          report_paths: junit-${{ inputs.min-python-version }}.xml
+      # - name: Status Check - Unit Tests on Python ${{ inputs.min-python-version }}
+      #   uses: mikepenz/action-junit-report@v5
+      #   if: hashFiles('junit-${{ inputs.min-python-version }}.xml') != ''
+      #   with:
+      #     check_name: Unit Tests on Python ${{ inputs.min-python-version }}
+      #     report_paths: junit-${{ inputs.min-python-version }}.xml
 
-      - name: Status Check - Unit Tests on Python ${{ inputs.max-python-version }}
-        uses: mikepenz/action-junit-report@v5
-        if: hashFiles('junit-${{ inputs.max-python-version }}.xml') != ''
-        with:
-          check_name: Unit Tests on Python ${{ inputs.max-python-version }}
-          report_paths: junit-${{ inputs.max-python-version }}.xml
+      # - name: Status Check - Unit Tests on Python ${{ inputs.max-python-version }}
+      #   uses: mikepenz/action-junit-report@v5
+      #   if: hashFiles('junit-${{ inputs.max-python-version }}.xml') != ''
+      #   with:
+      #     check_name: Unit Tests on Python ${{ inputs.max-python-version }}
+      #     report_paths: junit-${{ inputs.max-python-version }}.xml
 
-      - name: Combine Coverage Reports
-        continue-on-error: true
-        if: hashFiles('*.cov') != ''
-        run: |
-          hatch run hatch-test.py${{ inputs.max-python-version }}:coverage combine
-        shell: bash
+      # - name: Combine Coverage Reports
+      #   continue-on-error: true
+      #   if: hashFiles('*.cov') != ''
+      #   run: |
+      #     hatch run hatch-test.py${{ inputs.max-python-version }}:coverage combine
+      #   shell: bash
 
-      - name: Report coverage
-        continue-on-error: true
-        if: hashFiles('*.cov') != ''
-        run: |
-          hatch run hatch-test.py${{ inputs.max-python-version }}:coverage xml
-        shell: bash
+      # - name: Report coverage
+      #   continue-on-error: true
+      #   if: hashFiles('*.cov') != ''
+      #   run: |
+      #     hatch run hatch-test.py${{ inputs.max-python-version }}:coverage xml
+      #   shell: bash
 
-      - name: SonarQube Scan
-        if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
-        uses: sonarsource/sonarqube-scan-action@v2.2.0
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-        with:
-          args: >
-            -Dsonar.tests=tests/
-            -Dsonar.verbose=true
-            -Dsonar.sources=src/
-            -Dsonar.projectKey=${{github.repository_owner}}_${{github.event.repository.name}}
-            -Dsonar.python.coverage.reportPaths=coverage.xml
-            -Dsonar.python.ruff.reportPaths=lint.json
+      # - name: SonarQube Scan
+      #   if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+      #   uses: sonarsource/sonarqube-scan-action@v2.2.0
+      #   env:
+      #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      #     SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+      #   with:
+      #     args: >
+      #       -Dsonar.tests=tests/
+      #       -Dsonar.verbose=true
+      #       -Dsonar.sources=src/
+      #       -Dsonar.projectKey=${{github.repository_owner}}_${{github.event.repository.name}}
+      #       -Dsonar.python.coverage.reportPaths=coverage.xml
+      #       -Dsonar.python.ruff.reportPaths=lint.json
 
-      - name: SonarQube Quality Gate check
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-        id: sonarqube-quality-gate-check
-        uses: sonarsource/sonarqube-quality-gate-action@master
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+      # - name: SonarQube Quality Gate check
+      #   if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+      #   id: sonarqube-quality-gate-check
+      #   uses: sonarsource/sonarqube-quality-gate-action@master
+      #   env:
+      #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      #     SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
 
-      - name: Comment on PR with Test Results
-        if: (hashFiles('junit-*.xml') != '') && (hashFiles('coverage.xml') != '')
-        continue-on-error: true
-        env:
-          MIN_PYTHON_VERSION_FILE: ${{ format('junit-{0}.xml', inputs.min-python-version) }}
-          MAX_PYTHON_VERSION_FILE: ${{ format('junit-{0}.xml', inputs.max-python-version) }}
-        uses: xportation/junit-coverage-report@main
-        with:
-          junit-path: ${{ hashFiles('junit-default.xml') != '' && 'junit-default.xml' || hashFiles(env.MIN_PYTHON_VERSION_FILE) != '' && env.MIN_PYTHON_VERSION_FILE || hashFiles(env.MAX_PYTHON_VERSION_FILE) != '' && env.MAX_PYTHON_VERSION_FILE }}
-          coverage-path: coverage.xml
+      # - name: Comment on PR with Test Results
+      #   if: (hashFiles('junit-*.xml') != '') && (hashFiles('coverage.xml') != '')
+      #   continue-on-error: true
+      #   env:
+      #     MIN_PYTHON_VERSION_FILE: ${{ format('junit-{0}.xml', inputs.min-python-version) }}
+      #     MAX_PYTHON_VERSION_FILE: ${{ format('junit-{0}.xml', inputs.max-python-version) }}
+      #   uses: xportation/junit-coverage-report@main
+      #   with:
+      #     junit-path: ${{ hashFiles('junit-default.xml') != '' && 'junit-default.xml' || hashFiles(env.MIN_PYTHON_VERSION_FILE) != '' && env.MIN_PYTHON_VERSION_FILE || hashFiles(env.MAX_PYTHON_VERSION_FILE) != '' && env.MAX_PYTHON_VERSION_FILE }}
+      #     coverage-path: coverage.xml
 
       - name: Build
         shell: bash
         run: hatch build
 
-      - name: Verify Packages
-        run: |
-          ls dist/*.tar.gz | xargs -n1 hatch run python -m twine check
-          ls dist/*.whl | xargs -n1 hatch run python -m twine check
-        shell: bash
+      # - name: Verify Packages
+      #   run: |
+      #     ls dist/*.tar.gz | xargs -n1 hatch run python -m twine check
+      #     ls dist/*.whl | xargs -n1 hatch run python -m twine check
+      #   shell: bash
 
 
       - name: Run Whitesource Scan

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -191,14 +191,14 @@ jobs:
           WS_PRODUCT_NAME: ${{ inputs.whitesource_product_name }}
           WS_PROJECT_NAME: ${{ inputs.whitesource_project_name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          AWS_REGION: ${{ vars.MANIFEST_AWS_REGION }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         with:
           entrypoint: /bin/sh
           args: >
             -c "
-            source $VIRTUAL_ENV/bin/activate &&
+            . $VIRTUAL_ENV/bin/activate &&
             cd $ACTIONS_PATH/whitesource-policy-violation-checker &&
             python whitesource_policy_violation_checker.py
             "
@@ -211,17 +211,15 @@ jobs:
           WS_PRODUCT_NAME: ${{ inputs.whitesource_product_name }}
           WS_PROJECT_NAME: ${{ inputs.whitesource_project_name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          AWS_REGION: ${{ vars.MANIFEST_AWS_REGION }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           WS_JIRA_CHECK: "False" #No Jira Search for Open Vulnerability Issues
         with:
           entrypoint: /bin/sh
           args: >
-            source $VIRTUAL_ENV/bin/activate &&
+            . $VIRTUAL_ENV/bin/activate &&
             cd $ACTIONS_PATH/whitesource-vulnerability-checker &&
             python whitesource_vulnerability_checker.py
-            "
-        
 
           

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -183,14 +183,14 @@ jobs:
           WS_PROJECT_NAME: ${{ inputs.whitesource_project_name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AWS_REGION: ${{ vars.MANIFEST_AWS_REGION }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.DYNAMODB_MANIFEST_READ_ONLY_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.DYNAMODB_MANIFEST_READ_ONLY_AWS_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         with:
           entrypoint: /bin/sh
           args: >
             -c "
-            export AWS_ACCESS_KEY_ID=${{ secrets.DYNAMODB_MANIFEST_READ_ONLY_AWS_ACCESS_KEY_ID }}
-            export AWS_SECRET_ACCESS_KEY=${{ secrets.DYNAMODB_MANIFEST_READ_ONLY_AWS_SECRET_ACCESS_KEY }}
+            export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
+            export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
             export GITHUB_ACTION_PATH=/maas-build-actions &&
             export VIRTUAL_ENV=$GITHUB_ACTION_PATH/venv &&
             source $VIRTUAL_ENV/bin/activate &&

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -184,6 +184,27 @@ jobs:
       #     whitesource_project_name: ${{ inputs.whitesource_project_name }}
       #     whitesource_api_key: ${{ secrets.WHITESOURCE_API_KEY }}
 
+      - name: Run WhiteSource Policy Gate
+        uses: docker://ghcr.io/solacedev/maas-build-actions:latest
+        env:
+          WS_API_KEY: ${{ secrets.WHITESOURCE_API_KEY }}
+          WS_PRODUCT_NAME: ${{ inputs.whitesource_product_name }}
+          WS_PROJECT_NAME: ${{ inputs.whitesource_project_name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AWS_REGION: ${{ vars.MANIFEST_AWS_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          ACTIONS_PATH: /maas-build-actions/actions
+          VIRUTAL_ENV: /maas-build-actions/venv
+        with:
+          entrypoint: /bin/sh
+          args: >
+            -c "
+            source $VIRTUAL_ENV/bin/activate &&
+            cd $ACTIONS_PATH/whitesource-policy-checker &&
+            python whitesource_policy_checker.py
+          "
+
       - name: Run WhiteSource Vulnerability Gate
         uses: docker://ghcr.io/solacedev/maas-build-actions:latest
         continue-on-error: true
@@ -207,24 +228,5 @@ jobs:
             python whitesource_vulnerability_checker.py
             "
         
-      - name: Run WhiteSource Policy Gate
-        uses: docker://ghcr.io/solacedev/maas-build-actions:latest
-        env:
-          WS_API_KEY: ${{ secrets.WHITESOURCE_API_KEY }}
-          WS_PRODUCT_NAME: ${{ inputs.whitesource_product_name }}
-          WS_PROJECT_NAME: ${{ inputs.whitesource_project_name }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          AWS_REGION: ${{ vars.MANIFEST_AWS_REGION }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          ACTIONS_PATH: /maas-build-actions/actions
-          VIRUTAL_ENV: /maas-build-actions/venv
-        with:
-          entrypoint: /bin/sh
-          args: >
-            -c "
-            source $VIRTUAL_ENV/bin/activate &&
-            cd $ACTIONS_PATH/whitesource-policy-checker &&
-            python whitesource_policy_checker.py
-            "
+
           

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -13,6 +13,14 @@ on:
         required: false
         default: "3.12"
         description: "Maximum Python version to test against."
+      whitesource_product_name:
+        type: string
+        required: false
+        description: "WhiteSource product name"
+      whitesource_project_name:
+        type: string
+        required: false
+        description: "WhiteSource project name"
     secrets:
       SONAR_TOKEN:
         description: "SonarQube token for the repository."
@@ -20,6 +28,14 @@ on:
       SONAR_HOST_URL:
         description: "SonarQube host URL for the repository."
         required: true
+      WHITESOURCE_API_KEY:
+        description: "WhiteSource API key"
+        required: false
+      PRISMA_ACCESS_KEY_ID:
+        description: "Prisma Access key ID"
+        required: false
+      PRISMA_SECRET_ACCESS_KEY:
+        required: false
 
 permissions:
   id-token: write
@@ -148,3 +164,30 @@ jobs:
           ls dist/*.tar.gz | xargs -n1 hatch run python -m twine check
           ls dist/*.whl | xargs -n1 hatch run python -m twine check
         shell: bash
+
+      - name: Print Debug Info
+        run: |
+          echo "Repository Owner: ${{ github.repository_owner }}"
+          echo "Repository Full Name: ${{ github.event.repository.full_name }}"
+          echo "Repository Name: ${{ github.event.repository.name }}"
+
+      - name: Run Whitesource Scan
+        if: ${{ github.repository_owner == 'SolaceDev' }}
+        id: whitesource-scan
+        uses: SolaceDev/solace-public-workflows/.github/actions/whitesource-scan@security_tools
+        with:
+          whitesource_product_name: ${{ inputs.whitesource_product_name }}
+          whitesource_project_name: ${{ inputs.whitesource_project_name }}
+          whitesource_api_key: ${{ secrets.WHITESOURCE_API_KEY }}
+
+      - name: Run WhiteSource Vulnerability and Policy Gate
+        uses: docker://ghcr.io/solacedev/maas-build-actions:sc_build_actions
+        with:
+          entrypoint: /bin/sh
+          args: >
+            -c
+            export GITHUB_ACTION_PATH=/maas-build-actions &&
+            export VIRTUAL_ENV=$GITHUB_ACTION_PATH/venv &&
+            source $VIRTUAL_ENV/bin/activate &&
+            cd actions/whitesource-project-state-checker && python whitesource_vulnurability_checker.py
+      

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -175,7 +175,11 @@ jobs:
         shell: bash
 
       - name: Run Whitesource Scan
-        if: ${{ github.repository_owner == 'SolaceDev' && inputs.whitesource_product_name != '' && inputs.whitesource_project_name != '' }}
+        if: ${{ 
+          github.repository_owner == 'SolaceDev' && 
+          inputs.whitesource_product_name != '' && 
+          inputs.whitesource_project_name != '' 
+          }}
         uses: SolaceDev/solace-public-workflows/.github/actions/whitesource-scan@security_tools
         with:
           whitesource_product_name: ${{ inputs.whitesource_product_name }}
@@ -183,7 +187,12 @@ jobs:
           whitesource_api_key: ${{ secrets.WHITESOURCE_API_KEY }}
 
       - name: Run WhiteSource Policy Gate
-        if: ${{ github.repository_owner == 'SolaceDev' && inputs.whitesource_product_name && inputs.whitesource_project_name && github.ref == 'refs/heads/main' }}
+        if: ${{ 
+          github.repository_owner == 'SolaceDev' && 
+          inputs.whitesource_product_name != '' && 
+          inputs.whitesource_project_name != '' && 
+          github.ref == 'refs/heads/main' 
+          }}
         uses: docker://ghcr.io/solacedev/maas-build-actions:ws_policy_checker_image
         env:
           WS_API_KEY: ${{ secrets.WHITESOURCE_API_KEY }}
@@ -203,7 +212,12 @@ jobs:
             "
 
       - name: Run WhiteSource Vulnerability Gate
-        if: ${{ github.repository_owner == 'SolaceDev' && inputs.whitesource_product_name && inputs.whitesource_project_name && github.ref == 'refs/heads/main' }}
+        if: ${{ 
+          github.repository_owner == 'SolaceDev' && 
+          inputs.whitesource_product_name != '' && 
+          inputs.whitesource_project_name != '' && 
+          github.ref == 'refs/heads/main' 
+          }}
         uses: docker://ghcr.io/solacedev/maas-build-actions:ws_policy_checker_image
         continue-on-error: true
         env:

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -20,6 +20,7 @@ on:
       whitesource_project_name:
         type: string
         required: false
+        default: ${{ github.event.repository.name }}
         description: "WhiteSource project name"
     secrets:
       SONAR_TOKEN:

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -184,5 +184,5 @@ jobs:
             export GITHUB_ACTION_PATH=/maas-build-actions &&
             export VIRTUAL_ENV=$GITHUB_ACTION_PATH/venv &&
             source $VIRTUAL_ENV/bin/activate &&
-            cd actions/whitesource-project-state-checker && python whitesource_vulnurability_checker.py
+            cd actions/whitesource-vulnerability-checker && python whitesource_vulnurability_checker.py
       

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -195,13 +195,8 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         with:
-          entrypoint: /bin/sh
-          args: >
-            -c "
-            . $VIRTUAL_ENV/bin/activate &&
-            cd $ACTIONS_PATH/whitesource-policy-violation-checker &&
-            python whitesource_policy_violation_checker.py
-            "
+          entrypoint: /bin/sh -c
+          args: ". $VIRTUAL_ENV/bin/activate && cd $ACTIONS_PATH/whitesource-policy-violation-checker && python whitesource_policy_violation_checker.py"
 
       - name: Run WhiteSource Vulnerability Gate
         uses: docker://ghcr.io/solacedev/maas-build-actions:ws_policy_checker_image
@@ -216,11 +211,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           WS_JIRA_CHECK: "False" #No Jira Search for Open Vulnerability Issues
         with:
-          entrypoint: /bin/sh
-          args: >
-            -c ". $VIRTUAL_ENV/bin/activate &&
-            cd $ACTIONS_PATH/whitesource-vulnerability-checker &&
-            python whitesource_vulnerability_checker.py
-            "
+          entrypoint: /bin/sh -c
+          args: ". $VIRTUAL_ENV/bin/activate && cd $ACTIONS_PATH/whitesource-vulnerability-checker && python whitesource_vulnerability_checker.py"
 
           

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -177,6 +177,14 @@ jobs:
 
       - name: Run WhiteSource Vulnerability and Policy Gate
         uses: docker://ghcr.io/solacedev/maas-build-actions:latest
+        env:
+          WS_API_KEY: ${{ secrets.WHITESOURCE_API_KEY }}
+          WS_PRODUCT_NAME: ${{ inputs.whitesource_product_name }}
+          WS_PROJECT_NAME: ${{ inputs.whitesource_project_name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.DYNAMODB_MANIFEST_READ_ONLY_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.DYNAMODB_MANIFEST_READ_ONLY_AWS_SECRET_ACCESS_KEY }}
         with:
           entrypoint: /bin/sh
           args: >


### PR DESCRIPTION
### What is the purpose of this change?
- Add github action for running whitesource scan
- Add policy get steps on Hatch CI. They will only run in SolaceDev for the mean time

### How is this accomplished?
- The github action white source scan is a clone in `maas-build-actions`
- The whitesource gate actions are using scripts in docker container (same as maas-build-actions) to execute the policy and vulnerability violation checkers.
 

### Anything reviews should focus on/be aware of?
Example of what the action would look like when we start enforcing or failing these vulnerability/policy violation
<img width="1196" alt="image" src="https://github.com/user-attachments/assets/54b1dac2-492a-4ed7-adf6-7f2d9a3bafca">
