### PR TITLE
DATAGO-91907: Configure Whitesource to accurately scan Hatch Projects

### DIFF
--- a/.github/actions/hatch-lint-test/action.yml
+++ b/.github/actions/hatch-lint-test/action.yml
@@ -92,7 +92,9 @@ runs:
     # Build and verify packages
     - name: Build
       shell: bash
-      run: hatch build
+      run: |
+        hatch build
+        hatch dep show requirements > requirements.txt
 
     - name: Verify Packages
       run: |

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -173,9 +173,9 @@ jobs:
       - name: Build
         shell: bash
         run: |
-          hatch build
           hatch run pip freeze > requirements.txt
-
+          hatch build
+          
       - name: Verify Packages
         run: |
           ls dist/*.tar.gz | xargs -n1 hatch run python -m twine check

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -219,6 +219,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.MANIFEST_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.MANIFEST_AWS_SECRET_ACCESS_KEY }}
           WS_BLOCKING_POLICY_VIOLATION_LEVELS: "Major,Minor"
+          FAIL_IF_POLICY_VIOLATIONS_FOUND: "True"
         with:
           entrypoint: /bin/sh
           args: >

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -75,100 +75,100 @@ jobs:
           min-python-version: ${{ inputs.min-python-version }}
           max-python-version: ${{ inputs.max-python-version }}
 
-      # - name: Run Lint
-      #   continue-on-error: true
-      #   run: |
-      #     hatch run hatch-static-analysis:ruff check -o lint.json --output-format json
-      #   shell: bash
+      - name: Run Lint
+        continue-on-error: true
+        run: |
+          hatch run hatch-static-analysis:ruff check -o lint.json --output-format json
+        shell: bash
 
-      # - name: Run Tests with default python version
-      #   shell: bash
-      #   if: steps.hatch-setup.outputs.matrix-present == 'false'
-      #   run: |
-      #     hatch run pytest --junitxml=junit-default.xml
+      - name: Run Tests with default python version
+        shell: bash
+        if: steps.hatch-setup.outputs.matrix-present == 'false'
+        run: |
+          hatch run pytest --junitxml=junit-default.xml
 
-      # - name: Run Unit Tests on Python ${{ inputs.min-python-version }}
-      #   continue-on-error: true
-      #   shell: bash
-      #   if: steps.hatch-setup.outputs.matrix-present == 'true'
-      #   run: |
-      #     hatch test --python ${{ inputs.min-python-version }}  --cover --parallel --junitxml=junit-${{ inputs.min-python-version }}.xml
+      - name: Run Unit Tests on Python ${{ inputs.min-python-version }}
+        continue-on-error: true
+        shell: bash
+        if: steps.hatch-setup.outputs.matrix-present == 'true'
+        run: |
+          hatch test --python ${{ inputs.min-python-version }}  --cover --parallel --junitxml=junit-${{ inputs.min-python-version }}.xml
 
-      # - name: Run Unit Tests on Python ${{ inputs.max-python-version }}
-      #   continue-on-error: true
-      #   shell: bash
-      #   if: steps.hatch-setup.outputs.matrix-present == 'true'
-      #   run: |
-      #     hatch test --python ${{ inputs.max-python-version }}  --cover --parallel --junitxml=junit-${{ inputs.max-python-version }}.xml
+      - name: Run Unit Tests on Python ${{ inputs.max-python-version }}
+        continue-on-error: true
+        shell: bash
+        if: steps.hatch-setup.outputs.matrix-present == 'true'
+        run: |
+          hatch test --python ${{ inputs.max-python-version }}  --cover --parallel --junitxml=junit-${{ inputs.max-python-version }}.xml
 
-      # - name: Status Check - Unit Tests on default python version
-      #   uses: mikepenz/action-junit-report@v5
-      #   if: hashFiles('junit-default.xml') != ''
-      #   with:
-      #     check_name: Unit Tests on default python version
-      #     report_paths: junit-default.xml
+      - name: Status Check - Unit Tests on default python version
+        uses: mikepenz/action-junit-report@v5
+        if: hashFiles('junit-default.xml') != ''
+        with:
+          check_name: Unit Tests on default python version
+          report_paths: junit-default.xml
 
-      # - name: Status Check - Unit Tests on Python ${{ inputs.min-python-version }}
-      #   uses: mikepenz/action-junit-report@v5
-      #   if: hashFiles('junit-${{ inputs.min-python-version }}.xml') != ''
-      #   with:
-      #     check_name: Unit Tests on Python ${{ inputs.min-python-version }}
-      #     report_paths: junit-${{ inputs.min-python-version }}.xml
+      - name: Status Check - Unit Tests on Python ${{ inputs.min-python-version }}
+        uses: mikepenz/action-junit-report@v5
+        if: hashFiles('junit-${{ inputs.min-python-version }}.xml') != ''
+        with:
+          check_name: Unit Tests on Python ${{ inputs.min-python-version }}
+          report_paths: junit-${{ inputs.min-python-version }}.xml
 
-      # - name: Status Check - Unit Tests on Python ${{ inputs.max-python-version }}
-      #   uses: mikepenz/action-junit-report@v5
-      #   if: hashFiles('junit-${{ inputs.max-python-version }}.xml') != ''
-      #   with:
-      #     check_name: Unit Tests on Python ${{ inputs.max-python-version }}
-      #     report_paths: junit-${{ inputs.max-python-version }}.xml
+      - name: Status Check - Unit Tests on Python ${{ inputs.max-python-version }}
+        uses: mikepenz/action-junit-report@v5
+        if: hashFiles('junit-${{ inputs.max-python-version }}.xml') != ''
+        with:
+          check_name: Unit Tests on Python ${{ inputs.max-python-version }}
+          report_paths: junit-${{ inputs.max-python-version }}.xml
 
-      # - name: Combine Coverage Reports
-      #   continue-on-error: true
-      #   if: hashFiles('*.cov') != ''
-      #   run: |
-      #     hatch run hatch-test.py${{ inputs.max-python-version }}:coverage combine
-      #   shell: bash
+      - name: Combine Coverage Reports
+        continue-on-error: true
+        if: hashFiles('*.cov') != ''
+        run: |
+          hatch run hatch-test.py${{ inputs.max-python-version }}:coverage combine
+        shell: bash
 
-      # - name: Report coverage
-      #   continue-on-error: true
-      #   if: hashFiles('*.cov') != ''
-      #   run: |
-      #     hatch run hatch-test.py${{ inputs.max-python-version }}:coverage xml
-      #   shell: bash
+      - name: Report coverage
+        continue-on-error: true
+        if: hashFiles('*.cov') != ''
+        run: |
+          hatch run hatch-test.py${{ inputs.max-python-version }}:coverage xml
+        shell: bash
 
-      # - name: SonarQube Scan
-      #   if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
-      #   uses: sonarsource/sonarqube-scan-action@v2.2.0
-      #   env:
-      #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      #     SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-      #   with:
-      #     args: >
-      #       -Dsonar.tests=tests/
-      #       -Dsonar.verbose=true
-      #       -Dsonar.sources=src/
-      #       -Dsonar.projectKey=${{github.repository_owner}}_${{github.event.repository.name}}
-      #       -Dsonar.python.coverage.reportPaths=coverage.xml
-      #       -Dsonar.python.ruff.reportPaths=lint.json
+      - name: SonarQube Scan
+        if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+        uses: sonarsource/sonarqube-scan-action@v2.2.0
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+        with:
+          args: >
+            -Dsonar.tests=tests/
+            -Dsonar.verbose=true
+            -Dsonar.sources=src/
+            -Dsonar.projectKey=${{github.repository_owner}}_${{github.event.repository.name}}
+            -Dsonar.python.coverage.reportPaths=coverage.xml
+            -Dsonar.python.ruff.reportPaths=lint.json
 
-      # - name: SonarQube Quality Gate check
-      #   if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-      #   id: sonarqube-quality-gate-check
-      #   uses: sonarsource/sonarqube-quality-gate-action@master
-      #   env:
-      #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      #     SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+      - name: SonarQube Quality Gate check
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        id: sonarqube-quality-gate-check
+        uses: sonarsource/sonarqube-quality-gate-action@master
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
 
-      # - name: Comment on PR with Test Results
-      #   if: (hashFiles('junit-*.xml') != '') && (hashFiles('coverage.xml') != '')
-      #   continue-on-error: true
-      #   env:
-      #     MIN_PYTHON_VERSION_FILE: ${{ format('junit-{0}.xml', inputs.min-python-version) }}
-      #     MAX_PYTHON_VERSION_FILE: ${{ format('junit-{0}.xml', inputs.max-python-version) }}
-      #   uses: xportation/junit-coverage-report@main
-      #   with:
-      #     junit-path: ${{ hashFiles('junit-default.xml') != '' && 'junit-default.xml' || hashFiles(env.MIN_PYTHON_VERSION_FILE) != '' && env.MIN_PYTHON_VERSION_FILE || hashFiles(env.MAX_PYTHON_VERSION_FILE) != '' && env.MAX_PYTHON_VERSION_FILE }}
-      #     coverage-path: coverage.xml
+      - name: Comment on PR with Test Results
+        if: (hashFiles('junit-*.xml') != '') && (hashFiles('coverage.xml') != '')
+        continue-on-error: true
+        env:
+          MIN_PYTHON_VERSION_FILE: ${{ format('junit-{0}.xml', inputs.min-python-version) }}
+          MAX_PYTHON_VERSION_FILE: ${{ format('junit-{0}.xml', inputs.max-python-version) }}
+        uses: xportation/junit-coverage-report@main
+        with:
+          junit-path: ${{ hashFiles('junit-default.xml') != '' && 'junit-default.xml' || hashFiles(env.MIN_PYTHON_VERSION_FILE) != '' && env.MIN_PYTHON_VERSION_FILE || hashFiles(env.MAX_PYTHON_VERSION_FILE) != '' && env.MAX_PYTHON_VERSION_FILE }}
+          coverage-path: coverage.xml
 
       - name: Build
         shell: bash
@@ -182,12 +182,7 @@ jobs:
           ls dist/*.whl | xargs -n1 hatch run python -m twine check
         shell: bash
       
-      # - name: Set up Python for Virtualenv used by Whitesource Scan
-      #   uses: actions/setup-python@v4
-      #   with:
-      #     python-version: ${{ inputs.min-python-version }}
-
-      - name: Install Virtualenv
+      - name: Install Virtualenv for Whitesource Scan
         run: |
           python -m pip install --upgrade pip
           pip install virtualenv
@@ -197,7 +192,7 @@ jobs:
           github.repository_owner == 'SolaceDev' && 
           inputs.whitesource_product_name != '' && 
           inputs.whitesource_project_name != '' &&
-          github.ref == 'refs/heads/include_ws_config' 
+          github.ref == 'refs/heads/main' 
           }}
         uses: SolaceDev/solace-public-workflows/.github/actions/whitesource-scan@main
         with:
@@ -211,7 +206,7 @@ jobs:
           github.repository_owner == 'SolaceDev' && 
           inputs.whitesource_product_name != '' && 
           inputs.whitesource_project_name != '' && 
-          github.ref == 'refs/heads/include_ws_config' 
+          github.ref == 'refs/heads/main' 
           }}
         uses: docker://ghcr.io/solacedev/maas-build-actions:latest
         env:

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -187,10 +187,10 @@ jobs:
       #   with:
       #     python-version: ${{ inputs.min-python-version }}
 
-      # - name: Install Virtualenv
-      #   run: |
-      #     python -m pip install --upgrade pip
-      #     pip install virtualenv
+      - name: Install Virtualenv
+        run: |
+          python -m pip install --upgrade pip
+          pip install virtualenv
 
       - name: Run Whitesource Scan
         if: ${{ 

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -155,15 +155,15 @@ jobs:
       #     SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
 
       # - name: Comment on PR with Test Results
-        if: (hashFiles('junit-*.xml') != '') && (hashFiles('coverage.xml') != '')
-        continue-on-error: true
-        env:
-          MIN_PYTHON_VERSION_FILE: ${{ format('junit-{0}.xml', inputs.min-python-version) }}
-          MAX_PYTHON_VERSION_FILE: ${{ format('junit-{0}.xml', inputs.max-python-version) }}
-        uses: xportation/junit-coverage-report@main
-        with:
-          junit-path: ${{ hashFiles('junit-default.xml') != '' && 'junit-default.xml' || hashFiles(env.MIN_PYTHON_VERSION_FILE) != '' && env.MIN_PYTHON_VERSION_FILE || hashFiles(env.MAX_PYTHON_VERSION_FILE) != '' && env.MAX_PYTHON_VERSION_FILE }}
-          coverage-path: coverage.xml
+      #   if: (hashFiles('junit-*.xml') != '') && (hashFiles('coverage.xml') != '')
+      #   continue-on-error: true
+      #   env:
+      #     MIN_PYTHON_VERSION_FILE: ${{ format('junit-{0}.xml', inputs.min-python-version) }}
+      #     MAX_PYTHON_VERSION_FILE: ${{ format('junit-{0}.xml', inputs.max-python-version) }}
+      #   uses: xportation/junit-coverage-report@main
+      #   with:
+      #     junit-path: ${{ hashFiles('junit-default.xml') != '' && 'junit-default.xml' || hashFiles(env.MIN_PYTHON_VERSION_FILE) != '' && env.MIN_PYTHON_VERSION_FILE || hashFiles(env.MAX_PYTHON_VERSION_FILE) != '' && env.MAX_PYTHON_VERSION_FILE }}
+      #     coverage-path: coverage.xml
 
       - name: Build
         shell: bash

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -22,6 +22,11 @@ on:
         required: false
         default: ${{ github.event.repository.name }}
         description: "WhiteSource project name"
+      whitesource_config_file:
+        type: string
+        required: false
+        default: ""
+        description: "WhiteSource configuration file"
     secrets:
       SONAR_TOKEN:
         description: "SonarQube token for the repository."
@@ -187,7 +192,7 @@ jobs:
           whitesource_product_name: ${{ inputs.whitesource_product_name }}
           whitesource_project_name: ${{ inputs.whitesource_project_name }}
           whitesource_api_key: ${{ secrets.WHITESOURCE_API_KEY }}
-          whitesource_config_file: ""
+          whitesource_config_file: ${{ inputs.whitesource_config_file }}
 
       - name: Run WhiteSource Policy Gate
         if: ${{ 

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -181,6 +181,13 @@ jobs:
           ls dist/*.tar.gz | xargs -n1 hatch run python -m twine check
           ls dist/*.whl | xargs -n1 hatch run python -m twine check
         shell: bash
+      
+
+
+      - name: Set up Python for Virtualenv used by Whitesource Scan
+        uses: actions/setup-python@v4
+        with:
+            python-version: ${{ inputs.min-python-version }}
 
       - name: Run Whitesource Scan
         if: ${{ 

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -182,12 +182,15 @@ jobs:
           ls dist/*.whl | xargs -n1 hatch run python -m twine check
         shell: bash
       
+      # - name: Set up Python for Virtualenv used by Whitesource Scan
+      #   uses: actions/setup-python@v4
+      #   with:
+      #     python-version: ${{ inputs.min-python-version }}
 
-
-      - name: Set up Python for Virtualenv used by Whitesource Scan
-        uses: actions/setup-python@v4
-        with:
-            python-version: ${{ inputs.min-python-version }}
+      - name: Install Virtualenv
+        run: |
+          python -m pip install --upgrade pip
+          pip install virtualenv
 
       - name: Run Whitesource Scan
         if: ${{ 

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -209,7 +209,7 @@ jobs:
           github.ref == 'refs/heads/include_ws_config' 
           }}
         uses: docker://ghcr.io/solacedev/maas-build-actions:latest
-        continue-on-error: true
+        continue-on-error: false
         env:
           WS_API_KEY: ${{ secrets.WHITESOURCE_API_KEY }}
           WS_PRODUCT_NAME: ${{ inputs.whitesource_product_name }}
@@ -233,7 +233,7 @@ jobs:
           github.repository_owner == 'SolaceDev' && 
           inputs.whitesource_product_name != '' && 
           inputs.whitesource_project_name != '' && 
-          github.ref == 'refs/heads/refs/heads/include_ws_config' 
+          github.ref == 'refs/heads/include_ws_config' 
           }}
         uses: docker://ghcr.io/solacedev/maas-build-actions:latest
         continue-on-error: true

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -192,7 +192,7 @@ jobs:
           github.repository_owner == 'SolaceDev' && 
           inputs.whitesource_product_name != '' && 
           inputs.whitesource_project_name != '' &&
-          github.ref == 'refs/heads/include_ws_config' 
+          github.ref == 'refs/heads/main' 
           }}
         uses: SolaceDev/solace-public-workflows/.github/actions/whitesource-scan@main
         with:
@@ -206,7 +206,7 @@ jobs:
           github.repository_owner == 'SolaceDev' && 
           inputs.whitesource_product_name != '' && 
           inputs.whitesource_project_name != '' && 
-          github.ref == 'refs/heads/include_ws_config' 
+          github.ref == 'refs/heads/main' 
           }}
         uses: docker://ghcr.io/solacedev/maas-build-actions:latest
         continue-on-error: true
@@ -234,7 +234,7 @@ jobs:
           github.repository_owner == 'SolaceDev' && 
           inputs.whitesource_product_name != '' && 
           inputs.whitesource_project_name != '' && 
-          github.ref == 'refs/heads/include_ws_config' 
+          github.ref == 'refs/heads/main' 
           }}
         uses: docker://ghcr.io/solacedev/maas-build-actions:latest
         continue-on-error: true

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -172,7 +172,9 @@ jobs:
 
       - name: Build
         shell: bash
-        run: hatch build
+        run: |
+          hatch build
+          hatch run pip freeze > requirements.txt
 
       - name: Verify Packages
         run: |

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -187,7 +187,7 @@ jobs:
           whitesource_product_name: ${{ inputs.whitesource_product_name }}
           whitesource_project_name: ${{ inputs.whitesource_project_name }}
           whitesource_api_key: ${{ secrets.WHITESOURCE_API_KEY }}
-          whitesource_config_file: wss-unified-agent.config
+          whitesource_config_file: ""
 
       - name: Run WhiteSource Policy Gate
         if: ${{ 

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -194,7 +194,7 @@ jobs:
           github.repository_owner == 'SolaceDev' && 
           inputs.whitesource_product_name != '' && 
           inputs.whitesource_project_name != '' && 
-          github.ref == 'refs/heads/main' 
+          github.ref == 'refs/heads/include_ws_config' 
           }}
         uses: docker://ghcr.io/solacedev/maas-build-actions:latest
         env:

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -192,7 +192,7 @@ jobs:
           github.repository_owner == 'SolaceDev' && 
           inputs.whitesource_product_name != '' && 
           inputs.whitesource_project_name != '' &&
-          github.ref == 'refs/heads/main' 
+          github.ref == 'refs/heads/refs/heads/include_ws_config' 
           }}
         uses: SolaceDev/solace-public-workflows/.github/actions/whitesource-scan@main
         with:
@@ -206,9 +206,10 @@ jobs:
           github.repository_owner == 'SolaceDev' && 
           inputs.whitesource_product_name != '' && 
           inputs.whitesource_project_name != '' && 
-          github.ref == 'refs/heads/main' 
+          github.ref == 'refs/heads/include_ws_config' 
           }}
         uses: docker://ghcr.io/solacedev/maas-build-actions:latest
+        continue-on-error: true
         env:
           WS_API_KEY: ${{ secrets.WHITESOURCE_API_KEY }}
           WS_PRODUCT_NAME: ${{ inputs.whitesource_product_name }}
@@ -217,7 +218,7 @@ jobs:
           AWS_REGION: ${{ vars.MANIFEST_AWS_REGION }}
           AWS_ACCESS_KEY_ID: ${{ secrets.MANIFEST_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.MANIFEST_AWS_SECRET_ACCESS_KEY }}
-          WS_BLOCKING_POLICY_VIOLATION_LEVELS: "major,minor"
+          WS_BLOCKING_POLICY_VIOLATION_LEVELS: "Major,Minor"
         with:
           entrypoint: /bin/sh
           args: >
@@ -232,7 +233,7 @@ jobs:
           github.repository_owner == 'SolaceDev' && 
           inputs.whitesource_product_name != '' && 
           inputs.whitesource_project_name != '' && 
-          github.ref == 'refs/heads/main' 
+          github.ref == 'refs/heads/refs/heads/include_ws_config' 
           }}
         uses: docker://ghcr.io/solacedev/maas-build-actions:latest
         continue-on-error: true

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -173,8 +173,8 @@ jobs:
       - name: Build
         shell: bash
         run: |
-          hatch run pip freeze > requirements.txt
           hatch build
+          hatch dep show requirements > requirements.txt
           
       - name: Verify Packages
         run: |
@@ -187,10 +187,10 @@ jobs:
       #   with:
       #     python-version: ${{ inputs.min-python-version }}
 
-      - name: Install Virtualenv
-        run: |
-          python -m pip install --upgrade pip
-          pip install virtualenv
+      # - name: Install Virtualenv
+      #   run: |
+      #     python -m pip install --upgrade pip
+      #     pip install virtualenv
 
       - name: Run Whitesource Scan
         if: ${{ 

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -192,7 +192,7 @@ jobs:
           github.repository_owner == 'SolaceDev' && 
           inputs.whitesource_product_name != '' && 
           inputs.whitesource_project_name != '' &&
-          github.ref == 'refs/heads/refs/heads/include_ws_config' 
+          github.ref == 'refs/heads/include_ws_config' 
           }}
         uses: SolaceDev/solace-public-workflows/.github/actions/whitesource-scan@main
         with:
@@ -209,7 +209,7 @@ jobs:
           github.ref == 'refs/heads/include_ws_config' 
           }}
         uses: docker://ghcr.io/solacedev/maas-build-actions:latest
-        continue-on-error: false
+        continue-on-error: true
         env:
           WS_API_KEY: ${{ secrets.WHITESOURCE_API_KEY }}
           WS_PRODUCT_NAME: ${{ inputs.whitesource_product_name }}

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -179,7 +179,8 @@ jobs:
         if: ${{ 
           github.repository_owner == 'SolaceDev' && 
           inputs.whitesource_product_name != '' && 
-          inputs.whitesource_project_name != '' 
+          inputs.whitesource_project_name != '' &&
+          github.ref == 'refs/heads/include_ws_config' 
           }}
         uses: SolaceDev/solace-public-workflows/.github/actions/whitesource-scan@main
         with:
@@ -203,6 +204,7 @@ jobs:
           AWS_REGION: ${{ vars.MANIFEST_AWS_REGION }}
           AWS_ACCESS_KEY_ID: ${{ secrets.MANIFEST_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.MANIFEST_AWS_SECRET_ACCESS_KEY }}
+          WS_BLOCKING_POLICY_VIOLATION_LEVELS: "major,minor"
         with:
           entrypoint: /bin/sh
           args: >

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -70,91 +70,91 @@ jobs:
           min-python-version: ${{ inputs.min-python-version }}
           max-python-version: ${{ inputs.max-python-version }}
 
-      - name: Run Lint
-        continue-on-error: true
-        run: |
-          hatch run hatch-static-analysis:ruff check -o lint.json --output-format json
-        shell: bash
+      # - name: Run Lint
+      #   continue-on-error: true
+      #   run: |
+      #     hatch run hatch-static-analysis:ruff check -o lint.json --output-format json
+      #   shell: bash
 
-      - name: Run Tests with default python version
-        shell: bash
-        if: steps.hatch-setup.outputs.matrix-present == 'false'
-        run: |
-          hatch run pytest --junitxml=junit-default.xml
+      # - name: Run Tests with default python version
+      #   shell: bash
+      #   if: steps.hatch-setup.outputs.matrix-present == 'false'
+      #   run: |
+      #     hatch run pytest --junitxml=junit-default.xml
 
-      - name: Run Unit Tests on Python ${{ inputs.min-python-version }}
-        continue-on-error: true
-        shell: bash
-        if: steps.hatch-setup.outputs.matrix-present == 'true'
-        run: |
-          hatch test --python ${{ inputs.min-python-version }}  --cover --parallel --junitxml=junit-${{ inputs.min-python-version }}.xml
+      # - name: Run Unit Tests on Python ${{ inputs.min-python-version }}
+      #   continue-on-error: true
+      #   shell: bash
+      #   if: steps.hatch-setup.outputs.matrix-present == 'true'
+      #   run: |
+      #     hatch test --python ${{ inputs.min-python-version }}  --cover --parallel --junitxml=junit-${{ inputs.min-python-version }}.xml
 
-      - name: Run Unit Tests on Python ${{ inputs.max-python-version }}
-        continue-on-error: true
-        shell: bash
-        if: steps.hatch-setup.outputs.matrix-present == 'true'
-        run: |
-          hatch test --python ${{ inputs.max-python-version }}  --cover --parallel --junitxml=junit-${{ inputs.max-python-version }}.xml
+      # - name: Run Unit Tests on Python ${{ inputs.max-python-version }}
+      #   continue-on-error: true
+      #   shell: bash
+      #   if: steps.hatch-setup.outputs.matrix-present == 'true'
+      #   run: |
+      #     hatch test --python ${{ inputs.max-python-version }}  --cover --parallel --junitxml=junit-${{ inputs.max-python-version }}.xml
 
-      - name: Status Check - Unit Tests on default python version
-        uses: mikepenz/action-junit-report@v5
-        if: hashFiles('junit-default.xml') != ''
-        with:
-          check_name: Unit Tests on default python version
-          report_paths: junit-default.xml
+      # - name: Status Check - Unit Tests on default python version
+      #   uses: mikepenz/action-junit-report@v5
+      #   if: hashFiles('junit-default.xml') != ''
+      #   with:
+      #     check_name: Unit Tests on default python version
+      #     report_paths: junit-default.xml
 
-      - name: Status Check - Unit Tests on Python ${{ inputs.min-python-version }}
-        uses: mikepenz/action-junit-report@v5
-        if: hashFiles('junit-${{ inputs.min-python-version }}.xml') != ''
-        with:
-          check_name: Unit Tests on Python ${{ inputs.min-python-version }}
-          report_paths: junit-${{ inputs.min-python-version }}.xml
+      # - name: Status Check - Unit Tests on Python ${{ inputs.min-python-version }}
+      #   uses: mikepenz/action-junit-report@v5
+      #   if: hashFiles('junit-${{ inputs.min-python-version }}.xml') != ''
+      #   with:
+      #     check_name: Unit Tests on Python ${{ inputs.min-python-version }}
+      #     report_paths: junit-${{ inputs.min-python-version }}.xml
 
-      - name: Status Check - Unit Tests on Python ${{ inputs.max-python-version }}
-        uses: mikepenz/action-junit-report@v5
-        if: hashFiles('junit-${{ inputs.max-python-version }}.xml') != ''
-        with:
-          check_name: Unit Tests on Python ${{ inputs.max-python-version }}
-          report_paths: junit-${{ inputs.max-python-version }}.xml
+      # - name: Status Check - Unit Tests on Python ${{ inputs.max-python-version }}
+      #   uses: mikepenz/action-junit-report@v5
+      #   if: hashFiles('junit-${{ inputs.max-python-version }}.xml') != ''
+      #   with:
+      #     check_name: Unit Tests on Python ${{ inputs.max-python-version }}
+      #     report_paths: junit-${{ inputs.max-python-version }}.xml
 
-      - name: Combine Coverage Reports
-        continue-on-error: true
-        if: hashFiles('*.cov') != ''
-        run: |
-          hatch run hatch-test.py${{ inputs.max-python-version }}:coverage combine
-        shell: bash
+      # - name: Combine Coverage Reports
+      #   continue-on-error: true
+      #   if: hashFiles('*.cov') != ''
+      #   run: |
+      #     hatch run hatch-test.py${{ inputs.max-python-version }}:coverage combine
+      #   shell: bash
 
-      - name: Report coverage
-        continue-on-error: true
-        if: hashFiles('*.cov') != ''
-        run: |
-          hatch run hatch-test.py${{ inputs.max-python-version }}:coverage xml
-        shell: bash
+      # - name: Report coverage
+      #   continue-on-error: true
+      #   if: hashFiles('*.cov') != ''
+      #   run: |
+      #     hatch run hatch-test.py${{ inputs.max-python-version }}:coverage xml
+      #   shell: bash
 
-      - name: SonarQube Scan
-        if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
-        uses: sonarsource/sonarqube-scan-action@v2.2.0
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-        with:
-          args: >
-            -Dsonar.tests=tests/
-            -Dsonar.verbose=true
-            -Dsonar.sources=src/
-            -Dsonar.projectKey=${{github.repository_owner}}_${{github.event.repository.name}}
-            -Dsonar.python.coverage.reportPaths=coverage.xml
-            -Dsonar.python.ruff.reportPaths=lint.json
+      # - name: SonarQube Scan
+      #   if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+      #   uses: sonarsource/sonarqube-scan-action@v2.2.0
+      #   env:
+      #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      #     SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+      #   with:
+      #     args: >
+      #       -Dsonar.tests=tests/
+      #       -Dsonar.verbose=true
+      #       -Dsonar.sources=src/
+      #       -Dsonar.projectKey=${{github.repository_owner}}_${{github.event.repository.name}}
+      #       -Dsonar.python.coverage.reportPaths=coverage.xml
+      #       -Dsonar.python.ruff.reportPaths=lint.json
 
-      - name: SonarQube Quality Gate check
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-        id: sonarqube-quality-gate-check
-        uses: sonarsource/sonarqube-quality-gate-action@master
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+      # - name: SonarQube Quality Gate check
+      #   if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+      #   id: sonarqube-quality-gate-check
+      #   uses: sonarsource/sonarqube-quality-gate-action@master
+      #   env:
+      #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      #     SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
 
-      - name: Comment on PR with Test Results
+      # - name: Comment on PR with Test Results
         if: (hashFiles('junit-*.xml') != '') && (hashFiles('coverage.xml') != '')
         continue-on-error: true
         env:
@@ -187,6 +187,7 @@ jobs:
           whitesource_product_name: ${{ inputs.whitesource_product_name }}
           whitesource_project_name: ${{ inputs.whitesource_project_name }}
           whitesource_api_key: ${{ secrets.WHITESOURCE_API_KEY }}
+          whitesource_config_file: wss-unified-agent.config
 
       - name: Run WhiteSource Policy Gate
         if: ${{ 


### PR DESCRIPTION
### What is the purpose of this change?
- Mend is unable to accurately scan python projects natively with hatch. The results are not all dependencies are identified by mend.
- To make this work, we need to produce a `requirements.txt` and use pip as a package manager. 
- Additional whitesource configuration file is required for python: This will be added per repository

### How is this accomplished?
- Add new input for the `whitesource_config_file path` on hatch-ci
### Anything reviews should focus on/be aware of?
- When the whitesource configuration file is not `set` this would be show the same results
- When the whitesource configuration file is set, we have more deps identified: https://github.com/SolaceDev/solace-ai-connector/actions/runs/12712719708/job/35449929860
