### PR TITLE
DATAGO-92574: Fix linter erros

### DIFF
--- a/.github/actions/hatch-lint-test/action.yml
+++ b/.github/actions/hatch-lint-test/action.yml
@@ -21,7 +21,17 @@ runs:
     - name: Run Lint
       continue-on-error: true
       run: |
-        hatch run hatch-static-analysis:ruff check -o lint.json --output-format json
+        # Verify where ruff check will run
+        hatch run hatch-static-analysis:ruff check ./src ./tests --show-files 
+        # Run ruff and capture its exit code
+        hatch run hatch-static-analysis:ruff check ./src ./tests -o lint.json --output-format json || true
+        # Verify if lint.json exists and contains valid JSON
+        if [ -f lint.json ] && jq empty lint.json 2>/dev/null; then
+          echo "Lint check completed successfully"
+        else
+          echo "Error: Lint check failed to produce valid output"
+          exit 1
+        fi
       shell: bash
 
     - name: Run Tests with default python version

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -77,9 +77,9 @@ jobs:
         continue-on-error: true
         run: |
           # Verify where ruff check will run
-          hatch run hatch-static-analysis:ruff check ./src --show-files 
+          hatch run hatch-static-analysis:ruff check . --show-files 
           # Run ruff and capture its exit code
-          hatch run hatch-static-analysis:ruff check ./src -o lint.json --output-format json || true
+          hatch run hatch-static-analysis:ruff check . -o lint.json --output-format json || true
           # Verify if lint.json exists and contains valid JSON
           if [ -f lint.json ] && jq empty lint.json 2>/dev/null; then
             echo "Lint check completed successfully"

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -77,9 +77,9 @@ jobs:
         continue-on-error: true
         run: |
           # Verify where ruff check will run
-          hatch run hatch-static-analysis:ruff check --show-files 
+          hatch run hatch-static-analysis:ruff check ./src --show-files 
           # Run ruff and capture its exit code
-          hatch run hatch-static-analysis:ruff check -o lint.json --output-format json || true
+          hatch run hatch-static-analysis:ruff check ./src -o lint.json --output-format json || true
           # Verify if lint.json exists and contains valid JSON
           if [ -f lint.json ] && jq empty lint.json 2>/dev/null; then
             echo "Lint check completed successfully"

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -76,6 +76,8 @@ jobs:
       - name: Run Lint
         continue-on-error: true
         run: |
+          # Verify where ruff check will run
+          hatch run hatch-static-analysis:ruff check --show-files 
           # Run ruff and capture its exit code
           hatch run hatch-static-analysis:ruff check -o lint.json --output-format json || true
           # Verify if lint.json exists and contains valid JSON

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -50,8 +50,6 @@ on:
         description: "AWS Secret Access Key"
         required: false
 
-
-
 permissions:
   id-token: write
   pull-requests: write
@@ -78,7 +76,15 @@ jobs:
       - name: Run Lint
         continue-on-error: true
         run: |
-          hatch run hatch-static-analysis:ruff check -o lint.json --output-format json
+          # Run ruff and capture its exit code
+          hatch run hatch-static-analysis:ruff check -o lint.json --output-format json || true
+          # Verify if lint.json exists and contains valid JSON
+          if [ -f lint.json ] && jq empty lint.json 2>/dev/null; then
+            echo "Lint check completed successfully"
+          else
+            echo "Error: Lint check failed to produce valid output"
+            exit 1
+          fi
         shell: bash
 
       - name: Run Tests with default python version
@@ -175,24 +181,24 @@ jobs:
         run: |
           hatch build
           hatch dep show requirements > requirements.txt
-          
+
       - name: Verify Packages
         run: |
           ls dist/*.tar.gz | xargs -n1 hatch run python -m twine check
           ls dist/*.whl | xargs -n1 hatch run python -m twine check
         shell: bash
-      
+
       - name: Install Virtualenv for Whitesource Scan
         run: |
           python -m pip install --upgrade pip
           pip install virtualenv
 
       - name: Run Whitesource Scan
-        if: ${{ 
-          github.repository_owner == 'SolaceDev' && 
-          inputs.whitesource_product_name != '' && 
+        if: ${{
+          github.repository_owner == 'SolaceDev' &&
+          inputs.whitesource_product_name != '' &&
           inputs.whitesource_project_name != '' &&
-          github.ref == 'refs/heads/main' 
+          github.ref == 'refs/heads/main'
           }}
         uses: SolaceDev/solace-public-workflows/.github/actions/whitesource-scan@main
         with:
@@ -202,11 +208,11 @@ jobs:
           whitesource_config_file: ${{ inputs.whitesource_config_file }}
 
       - name: Run WhiteSource Policy Gate
-        if: ${{ 
-          github.repository_owner == 'SolaceDev' && 
-          inputs.whitesource_product_name != '' && 
-          inputs.whitesource_project_name != '' && 
-          github.ref == 'refs/heads/main' 
+        if: ${{
+          github.repository_owner == 'SolaceDev' &&
+          inputs.whitesource_product_name != '' &&
+          inputs.whitesource_project_name != '' &&
+          github.ref == 'refs/heads/main'
           }}
         uses: docker://ghcr.io/solacedev/maas-build-actions:latest
         continue-on-error: true
@@ -230,11 +236,11 @@ jobs:
             "
 
       - name: Run WhiteSource Vulnerability Gate
-        if: ${{ 
-          github.repository_owner == 'SolaceDev' && 
-          inputs.whitesource_product_name != '' && 
-          inputs.whitesource_project_name != '' && 
-          github.ref == 'refs/heads/main' 
+        if: ${{
+          github.repository_owner == 'SolaceDev' &&
+          inputs.whitesource_product_name != '' &&
+          inputs.whitesource_project_name != '' &&
+          github.ref == 'refs/heads/main'
           }}
         uses: docker://ghcr.io/solacedev/maas-build-actions:latest
         continue-on-error: true

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -145,7 +145,7 @@ jobs:
         shell: bash
 
       - name: SonarQube Scan
-        if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: sonarsource/sonarqube-scan-action@v2.2.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -77,9 +77,9 @@ jobs:
         continue-on-error: true
         run: |
           # Verify where ruff check will run
-          hatch run hatch-static-analysis:ruff check . --show-files 
+          hatch run hatch-static-analysis:ruff check ./src ./tests --show-files 
           # Run ruff and capture its exit code
-          hatch run hatch-static-analysis:ruff check . -o lint.json --output-format json || true
+          hatch run hatch-static-analysis:ruff check ./src ./tests -o lint.json --output-format json || true
           # Verify if lint.json exists and contains valid JSON
           if [ -f lint.json ] && jq empty lint.json 2>/dev/null; then
             echo "Lint check completed successfully"


### PR DESCRIPTION
[DATAGO-92574](https://sol-jira.atlassian.net/browse/DATAGO-92574l)

### What is the purpose of this change?

- Fix persistent [linter errors](https://github.com/SolaceDev/solace-ai-connector-web/actions/runs/12772574342/job/35602444177) in CI runs
- Make SonarQube job only run on pull_request events as [push job fails](https://github.com/SolaceDev/solace-ai-connector/runs/35599540903) even when the [PR job is successfull](https://github.com/SolaceDev/solace-ai-connector/pull/80/checks?check_run_id=35599077397)

### How is this accomplished?

- Turns out the linter was failing because ruff check was running on some of the library files. 
Which can be seen if we run it with `hatch run hatch-static-analysis:ruff check --show-files `
```
/home/runner/work/solace-ai-connector-web/solace-ai-connector-web/.hatch_data/pythons/3.12/python/lib/python3.12/zipimport.py
/home/runner/work/solace-ai-connector-web/solace-ai-connector-web/.hatch_data/pythons/3.12/python/lib/python3.12/zoneinfo/__init__.py
/home/runner/work/solace-ai-connector-web/solace-ai-connector-web/.hatch_data/pythons/3.12/python/lib/python3.12/zoneinfo/_common.py
/home/runner/work/solace-ai-connector-web/solace-ai-connector-web/.hatch_data/pythons/3.12/python/lib/python3.12/zoneinfo/_tzpath.py
...
/home/runner/work/solace-ai-connector-web/solace-ai-connector-web/src/solace_ai_connector_web/components/web_output.py
/home/runner/work/solace-ai-connector-web/solace-ai-connector-web/tests/test_basic.py
error: Failed to parse .hatch_data/pythons/3.12/python/lib/Tix8.4.3/pref/WmDefault.py:86:1: unindent does not match any outer indentation level
error: Failed to parse .hatch_data/pythons/3.10/python/lib/Tix8.4.3/pref/WmDefault.py:86:1: unindent does not match any outer indentation level
Lint check completed successfully
```
we can fix it by specifying `./src` and `./test` as the folders for the lint


[DATAGO-92574]: https://sol-jira.atlassian.net/browse/DATAGO-92574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ