### PR TITLE
DATAGO-96937: Bump PyPi release action version

### DIFF
--- a/.github/workflows/hatch_release_pypi.yml
+++ b/.github/workflows/hatch_release_pypi.yml
@@ -97,8 +97,9 @@ jobs:
         run: hatch build
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
+          verbose: true
           password: ${{ secrets.PYPI_TOKEN }}
 
       - name: Create Release


### PR DESCRIPTION
### What is the purpose of this change?

- Bump release action version
- add verbose param
