### PR TITLE
DATAGO-96948 Include NPM builds and dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,23 @@
+# Set update schedule for GitHub Actions
+version: 2
+
+registries:
+  github:
+    type: git
+    url: https://github.com
+    username: x-access-token
+    password: ${{ secrets.PAT }}
+
+updates:
+  # Scan for updates under ./github/workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    registries: "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "./github/actions"
+    schedule:
+      interval: "weekly"
+    registries: "*"

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -27,6 +27,21 @@ on:
         required: false
         default: ""
         description: "WhiteSource configuration file"
+      npm_package_path:
+        type: string
+        required: false
+        default: ""
+        description: "Path to the npm package"
+      node_version:
+        type: string
+        required: false
+        default: "20"
+        description: "Node version to use for the npm package"
+      npm_lock_file:
+        type: string
+        required: false
+        default: "package-lock.json"
+        description: "Path to the npm lock file"
     secrets:
       SONAR_TOKEN:
         description: "SonarQube token for the repository."
@@ -177,6 +192,21 @@ jobs:
         with:
           junit-path: ${{ hashFiles('junit-default.xml') != '' && 'junit-default.xml' || hashFiles(env.MIN_PYTHON_VERSION_FILE) != '' && env.MIN_PYTHON_VERSION_FILE || hashFiles(env.MAX_PYTHON_VERSION_FILE) != '' && env.MAX_PYTHON_VERSION_FILE }}
           coverage-path: coverage.xml
+
+      - name: Setup Node.js
+        if: inputs.npm_package_path != ''
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node_version }}
+          cache: "npm"
+          cache-dependency-path: ${{ inputs.npm_package_path }}/${{ inputs.npm_lock_file }}
+
+      - name: Install Dependencies
+        if: inputs.npm_package_path != ''
+        run: |
+          cd ${{ inputs.npm_package_path }}
+          npm install
+          npm run build
 
       - name: Build
         shell: bash

--- a/.github/workflows/hatch_release_pypi.yml
+++ b/.github/workflows/hatch_release_pypi.yml
@@ -15,6 +15,21 @@ on:
         description: "PyPi repository to release to."
         type: string
         required: true
+      npm_package_path:
+        type: string
+        required: false
+        default: ""
+        description: "Path to the npm package"
+      node_version:
+        type: string
+        required: false
+        default: "20"
+        description: "Node version to use for the npm package"
+      npm_lock_file:
+        type: string
+        required: false
+        default: "package-lock.json"
+        description: "Path to the npm lock file"
     secrets:
       COMMIT_KEY:
         description: "SSH private key for the repository."
@@ -41,6 +56,21 @@ jobs:
 
       - name: Set up Hatch
         uses: SolaceDev/solace-public-workflows/.github/actions/hatch-setup@main
+
+      - name: Setup Node.js
+        if: inputs.npm_package_path != ''
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node_version }}
+          cache: "npm"
+          cache-dependency-path: ${{ inputs.npm_package_path }}/${{ inputs.npm_lock_file }}
+
+      - name: Install Dependencies
+        if: inputs.npm_package_path != ''
+        run: |
+          cd ${{ inputs.npm_package_path }}
+          npm install
+          npm run build
 
       - name: Get Current Version
         id: current_version


### PR DESCRIPTION
### What is the purpose of this change?

- solace-agent-mesh and solace-ai-connector-web both Include npm builds included in the wheel. 
This adds support for that so we can reuse the workflows there 
- Add dependabot
