### PR TITLE
DATAGO-98320: Use setup-python action to install python instead of hatch

### DIFF
--- a/.github/actions/hatch-setup/action.yml
+++ b/.github/actions/hatch-setup/action.yml
@@ -62,6 +62,7 @@ runs:
         key: ${{ runner.os }}-hatch-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('requirements.txt') }}
 
     - name: Install Hatch Matrix Python Versions
+      id: setup-python
       if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'true'
       uses: hatch-community/setup-python@v5.5.0
       with:
@@ -72,6 +73,7 @@ runs:
         cache-dependency-path: "pyproject.toml"
 
     - name: Install Hatch Matrix Python Versions
+      id: setup-python
       if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'false'
       uses: hatch-community/setup-python@v5.5.0
       with:
@@ -109,12 +111,23 @@ runs:
 
     - name: Install Dependencies
       shell: bash
+      env:
+        HATCH_PYTHON_PATH: ${{ steps.setup-python.outputs.pythonLocation }}
       if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'false'
       run: |
         hatch env create
+    - name: Create Hatch Environment for Matrix Python Versions
+      shell: bash
+      env:
+        HATCH_PYTHON_PATH: ${{ steps.setup-python.outputs.pythonLocation }}
+      run: |
+        hatch env create hatch-test.py${{ inputs.min-python-version }}
+        hatch env create hatch-test.py${{ inputs.max-python-version }}
 
     - name: Install Dependencies for default python version
       shell: bash
+      env:
+        HATCH_PYTHON_PATH: ${{ steps.setup-python.outputs.pythonLocation }}
       if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'false'
       run: |
         hatch run pip install --upgrade pip

--- a/.github/actions/hatch-setup/action.yml
+++ b/.github/actions/hatch-setup/action.yml
@@ -81,24 +81,10 @@ runs:
         cache: "pip"
         cache-dependency-path: "pyproject.toml"
 
-    - name: Export Hatch Python Path
+    - name: Export Python Path For Hatch
       shell: bash
       run: |
-        if [ "${{ steps.test-matrix-present.outputs.matrix-present }}" == "true" ]; then
-          # Get short python version, like "3.10", "3.11", "3.12"
-          # MIN_PYTHON_VERSION_SHORT=$(echo "${{ inputs.min-python-version }}" | cut -d. -f1,2)
-          # MAX_PYTHON_VERSION_SHORT=$(echo "${{ inputs.max-python-version }}" | cut -d. -f1,2)
-          
-          # # Set hatch enviornment variable name for python Distribution eg. HATCH_PYTHON_SOURCE_PYPY3_10
-          # MIN_VERSION_ENV_NAME="HATCH_PYTHON_SOURCE_PYPY${MIN_PYTHON_VERSION_SHORT//./\_}"
-          # MAX_VERSION_ENV_NAME="HATCH_PYTHON_SOURCE_PYPY${MAX_PYTHON_VERSION_SHORT//./\_}"
-
-          
-
-          # # Set the hatch enviornment variable for the python distribution
-          # echo "${MIN_VERSION_ENV_NAME}=${{ steps.setup-python.outputs.python-path }}" >> $GITHUB_ENV
-          # echo "${MAX_VERSION_ENV_NAME}=${{ steps.setup-python.outputs.python-path }}" >> $GITHUB_ENV
-          
+        if [ "${{ steps.test-matrix-present.outputs.matrix-present }}" == "true" ]; then          
           echo "HATCH_PYTHON_PATH=${{ steps.setup-python.outputs.python-path }}" >> $GITHUB_ENV
         elif [ "${{ steps.test-matrix-present.outputs.matrix-present }}" == "false" ]; then
           echo "HATCH_PYTHON_PATH=${{ steps.setup-python-default.outputs.python-path }}" >> $GITHUB_ENV

--- a/.github/actions/hatch-setup/action.yml
+++ b/.github/actions/hatch-setup/action.yml
@@ -64,7 +64,7 @@ runs:
     - name: Install Hatch Matrix Python Versions
       id: setup-python
       if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'true'
-      uses: hatch-community/setup-python@v5.5.0
+      uses: actions/setup-python@v5.5.0
       with:
         python-versions: |
           ${{ inputs.min-python-version }}
@@ -75,7 +75,7 @@ runs:
     - name: Install Hatch Matrix Python Versions
       id: setup-python-default
       if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'false'
-      uses: hatch-community/setup-python@v5.5.0
+      uses: actions/setup-python@v5.5.0
       with:
         python-version-file: "pyproject.toml"
         cache: "pip"

--- a/.github/actions/hatch-setup/action.yml
+++ b/.github/actions/hatch-setup/action.yml
@@ -3,7 +3,7 @@ description: Hatch install with support for caching of dependency groups.
 inputs:
   min-python-version:
     description: "Minimum Python version to support."
-    default: "3.10.16"
+    default: "3.10"
   max-python-version:
     description: "Maximum Python version to support."
     default: "3.13"
@@ -61,40 +61,37 @@ runs:
           ${{ env.HATCH_DATA_DIR }}
         key: ${{ runner.os }}-hatch-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('requirements.txt') }}
 
-    - name: Install Python
-      uses: actions/setup-python@v5
-      if: steps.test-matrix-present.outputs.matrix-present == 'true'
-      with:
-        python-version: |
-          ${{ inputs.min-python-version }}
-          ${{ inputs.max-python-version }}
-        cache: "pip"
-        cache-dependency-path: pyproject.toml
+    - name: Install Hatch Python
+      shell: bash
+      if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'true'
+      run: |
+        hatch python install ${{ inputs.min-python-version }} ${{ inputs.max-python-version }}
 
-    - name: Install Python
-      uses: actions/setup-python@v5
-      if: steps.test-matrix-present.outputs.matrix-present == 'false'
-      with:
-        python-version-file: pyproject.toml
-        cache: "pip"
-        cache-dependency-path: pyproject.toml
+    - name: Install Hatch Python
+      shell: bash
+      if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'false'
+      run: |
+        hatch python install ${{ inputs.max-python-version }}
 
     - name: Install Dependencies
       shell: bash
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'false'
       run: |
         hatch env create
+
+    - name: Install Dependencies for test matrix
+      shell: bash
+      if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'true'
+      run: |
+        hatch env create hatch-test.py${{ inputs.min-python-version }}
+        hatch env create hatch-test.py${{ inputs.max-python-version }}
 
     - name: Install Requirements.txt Dependencies for default python version
       shell: bash
       if: hashFiles('requirements.txt') != '' && steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'false'
       run: |
+        hatch run pip install --upgrade pip
         hatch run pip install --upgrade -r requirements.txt
-
-    - name: Install test dependencies for default python version
-      shell: bash
-      if: steps.cache.outputs.cache-hit != 'true'
-      run: |
         hatch run pip install twine pytest pytest-cov
 
     - name: Install Requirements.txt Dependencies for test matrix python version

--- a/.github/actions/hatch-setup/action.yml
+++ b/.github/actions/hatch-setup/action.yml
@@ -66,7 +66,7 @@ runs:
       if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'true'
       uses: actions/setup-python@v5.5.0
       with:
-        python-versions: |
+        python-version: |
           ${{ inputs.min-python-version }}
           ${{ inputs.max-python-version }}
         cache: "pip"

--- a/.github/actions/hatch-setup/action.yml
+++ b/.github/actions/hatch-setup/action.yml
@@ -86,49 +86,38 @@ runs:
       run: |
         if [ "${{ steps.test-matrix-present.outputs.matrix-present }}" == "true" ]; then
           # Get short python version, like "3.10", "3.11", "3.12"
-          MIN_PYTHON_VERSION_SHORT=$(echo "${{ inputs.min-python-version }}" | cut -d. -f1,2)
-          MAX_PYTHON_VERSION_SHORT=$(echo "${{ inputs.max-python-version }}" | cut -d. -f1,2)
+          # MIN_PYTHON_VERSION_SHORT=$(echo "${{ inputs.min-python-version }}" | cut -d. -f1,2)
+          # MAX_PYTHON_VERSION_SHORT=$(echo "${{ inputs.max-python-version }}" | cut -d. -f1,2)
           
-          # Find the path to the python version in the hatch directory
-          min_version_path=$(hatch python find $MIN_PYTHON_VERSION_SHORT)
-          max_version_path=$(hatch python find $MAX_PYTHON_VERSION_SHORT)
+          # # Set hatch enviornment variable name for python Distribution eg. HATCH_PYTHON_SOURCE_PYPY3_10
+          # MIN_VERSION_ENV_NAME="HATCH_PYTHON_SOURCE_PYPY${MIN_PYTHON_VERSION_SHORT//./\_}"
+          # MAX_VERSION_ENV_NAME="HATCH_PYTHON_SOURCE_PYPY${MAX_PYTHON_VERSION_SHORT//./\_}"
 
-          echo "Min Version Path: $min_version_path"
-          echo "Max Version Path: $max_version_path"
+          
 
-          hatch python show
-
-          # Set hatch enviornment variable name for python Distribution eg. HATCH_PYTHON_SOURCE_PYPY3_10
-          MIN_VERSION_ENV_NAME="HATCH_PYTHON_SOURCE_PYPY${MIN_PYTHON_VERSION_SHORT//./\_}"
-          MAX_VERSION_ENV_NAME="HATCH_PYTHON_SOURCE_PYPY${MAX_PYTHON_VERSION_SHORT//./\_}"
-
-          # Set the hatch enviornment variable for the python distribution
-          echo "${MIN_VERSION_ENV_NAME}=${min_version_path}" >> $GITHUB_ENV
-          echo "${MAX_VERSION_ENV_NAME}=${max_version_path}" >> $GITHUB_ENV
+          # # Set the hatch enviornment variable for the python distribution
+          # echo "${MIN_VERSION_ENV_NAME}=${{ steps.setup-python.outputs.python-path }}" >> $GITHUB_ENV
+          # echo "${MAX_VERSION_ENV_NAME}=${{ steps.setup-python.outputs.python-path }}" >> $GITHUB_ENV
+          
+          echo "HATCH_PYTHON_PATH=${{ steps.setup-python.outputs.python-path }}" >> $GITHUB_ENV
         elif [ "${{ steps.test-matrix-present.outputs.matrix-present }}" == "false" ]; then
-          echo "HATCH_PYTHON_PATH=${{ steps.hatch-setup.outputs.hatch-python-path }}" >> $GITHUB_ENV
+          echo "HATCH_PYTHON_PATH=${{ steps.setup-python-default.outputs.python-path }}" >> $GITHUB_ENV
         fi
 
     - name: Install Dependencies
       shell: bash
-      env:
-        HATCH_PYTHON_PATH: ${{ steps.setup-python-default.outputs.pythonLocation }}
       if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'false'
       run: |
         hatch env create
 
     - name: Create Hatch Environment for Matrix Python Versions
       shell: bash
-      env:
-        HATCH_PYTHON_PATH: ${{ steps.setup-python.outputs.pythonLocation }}
       run: |
         hatch env create hatch-test.py${{ inputs.min-python-version }}
         hatch env create hatch-test.py${{ inputs.max-python-version }}
 
     - name: Install Dependencies for default python version
       shell: bash
-      env:
-        HATCH_PYTHON_PATH: ${{ steps.setup-python-default.outputs.pythonLocation }}
       if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'false'
       run: |
         hatch run pip install --upgrade pip
@@ -136,8 +125,6 @@ runs:
 
     - name: Install Dependencies for test matrix python version
       shell: bash
-      env:
-        HATCH_PYTHON_PATH: ${{ steps.setup-python.outputs.pythonLocation }}
       if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'true'
       run: |
         hatch run hatch-test.py${{ inputs.min-python-version }}:pip install --upgrade pip

--- a/.github/actions/hatch-setup/action.yml
+++ b/.github/actions/hatch-setup/action.yml
@@ -62,16 +62,22 @@ runs:
         key: ${{ runner.os }}-hatch-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('requirements.txt') }}
 
     - name: Install Hatch Matrix Python Versions
-      shell: bash
       if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'true'
-      run: |
-        hatch python install ${{ inputs.min-python-version }} ${{ inputs.max-python-version }}
+      uses: hatch-community/setup-python@v5.5.0
+      with:
+        python-versions: |
+          ${{ inputs.min-python-version }}
+          ${{ inputs.max-python-version }}
+        cache: "pip"
+        cache-dependency-path: "pyproject.toml"
 
-    - name: Install Default Python
-      shell: bash
+    - name: Install Hatch Matrix Python Versions
       if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'false'
-      run: |
-        hatch python install ${{ inputs.max-python-version }}
+      uses: hatch-community/setup-python@v5.5.0
+      with:
+        python-version-file: "pyproject.toml"
+        cache: "pip"
+        cache-dependency-path: "pyproject.toml"
 
     - name: Export Hatch Python Path
       shell: bash
@@ -106,18 +112,6 @@ runs:
       if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'false'
       run: |
         hatch env create
-
-    - name: Install Dependencies for test matrix
-      shell: bash
-      if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'true'
-      run: |
-        echo "CPU Information:"
-        cat /proc/cpuinfo
-        echo "Number of CPU Cores:"
-        nproc
-        echo "-------------------"
-        hatch env create hatch-test.py${{ inputs.min-python-version }}
-        hatch env create hatch-test.py${{ inputs.max-python-version }}
 
     - name: Install Dependencies for default python version
       shell: bash

--- a/.github/actions/hatch-setup/action.yml
+++ b/.github/actions/hatch-setup/action.yml
@@ -3,10 +3,10 @@ description: Hatch install with support for caching of dependency groups.
 inputs:
   min-python-version:
     description: "Minimum Python version to support."
-    default: "3.10"
+    default: "3.10.16"
   max-python-version:
     description: "Maximum Python version to support."
-    default: "3.12"
+    default: "3.13"
 outputs:
   matrix-present:
     description: "Whether the test matrix is present."
@@ -61,17 +61,12 @@ runs:
           ${{ env.HATCH_DATA_DIR }}
         key: ${{ runner.os }}-hatch-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('requirements.txt') }}
 
-    - name: Install Hatch Python
-      shell: bash
-      if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'true'
-      run: |
-        hatch python install ${{ inputs.min-python-version }} ${{ inputs.max-python-version }}
-
-    - name: Install Hatch Python
-      shell: bash
-      if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'false'
-      run: |
-        hatch python install ${{ inputs.max-python-version }}
+    - name: Install Python
+      uses: actions/setup-python@v5
+      with:
+        python-version-file: pyproject.toml
+        cache: "pip"
+        cache-dependency-path: pyproject.toml
 
     - name: Install Dependencies
       shell: bash

--- a/.github/actions/hatch-setup/action.yml
+++ b/.github/actions/hatch-setup/action.yml
@@ -61,7 +61,7 @@ runs:
           ${{ env.HATCH_DATA_DIR }}
         key: ${{ runner.os }}-hatch-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('requirements.txt') }}
 
-    - name: Install Hatch Matrix Python Versions
+    - name: Install Python Versions for Hatch Test Matrix
       id: setup-python
       if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'true'
       uses: actions/setup-python@v5.5.0
@@ -72,7 +72,7 @@ runs:
         cache: "pip"
         cache-dependency-path: "pyproject.toml"
 
-    - name: Install Hatch Matrix Python Versions
+    - name: Install Python Version from pyproject.toml
       id: setup-python-default
       if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'false'
       uses: actions/setup-python@v5.5.0

--- a/.github/actions/hatch-setup/action.yml
+++ b/.github/actions/hatch-setup/action.yml
@@ -63,6 +63,17 @@ runs:
 
     - name: Install Python
       uses: actions/setup-python@v5
+      if: steps.test-matrix-present.outputs.matrix-present == 'true'
+      with:
+        python-version: |
+          ${{ inputs.min-python-version }}
+          ${{ inputs.max-python-version }}
+        cache: "pip"
+        cache-dependency-path: pyproject.toml
+
+    - name: Install Python
+      uses: actions/setup-python@v5
+      if: steps.test-matrix-present.outputs.matrix-present == 'true'
       with:
         python-version-file: pyproject.toml
         cache: "pip"

--- a/.github/actions/hatch-setup/action.yml
+++ b/.github/actions/hatch-setup/action.yml
@@ -95,7 +95,7 @@ runs:
           # Set the hatch enviornment variable for the python distribution
           echo "${MIN_VERSION_ENV_NAME}=${min_version_path}" >> $GITHUB_ENV
           echo "${MAX_VERSION_ENV_NAME}=${max_version_path}" >> $GITHUB_ENV
-        else if [ "${{ steps.test-matrix-present.outputs.matrix-present }}" == "false" ]; then
+        elif [ "${{ steps.test-matrix-present.outputs.matrix-present }}" == "false" ]; then
           echo "HATCH_PYTHON_PATH=${{ steps.hatch-setup.outputs.hatch-python-path }}" >> $GITHUB_ENV
         fi
 

--- a/.github/actions/hatch-setup/action.yml
+++ b/.github/actions/hatch-setup/action.yml
@@ -61,17 +61,43 @@ runs:
           ${{ env.HATCH_DATA_DIR }}
         key: ${{ runner.os }}-hatch-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('requirements.txt') }}
 
-    - name: Install Hatch Python
+    - name: Install Hatch Matrix Python Versions
       shell: bash
       if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'true'
       run: |
         hatch python install ${{ inputs.min-python-version }} ${{ inputs.max-python-version }}
 
-    - name: Install Hatch Python
+    - name: Install Default Python
       shell: bash
       if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'false'
       run: |
         hatch python install ${{ inputs.max-python-version }}
+
+    - name: Export Hatch Python Path
+      shell: bash
+      run: |
+        if [ "${{ steps.test-matrix-present.outputs.matrix-present }}" == "true" ]; then
+          # Get short python version, like "3.10", "3.11", "3.12"
+          MIN_PYTHON_VERSION_SHORT=$(echo "${{ inputs.min-python-version }}" | cut -d. -f1,2)
+          MAX_PYTHON_VERSION_SHORT=$(echo "${{ inputs.max-python-version }}" | cut -d. -f1,2)
+          
+          # Find the path to the python version in the hatch directory
+          min_version_path=$(hatch python find $MIN_PYTHON_VERSION_SHORT)
+          max_version_path=$(hatch python find $MAX_PYTHON_VERSION_SHORT)
+
+          echo "Min Version Path: $min_version_path"
+          echo "Max Version Path: $max_version_path"
+
+          # Set hatch enviornment variable name for python Distribution eg. HATCH_PYTHON_SOURCE_PYPY3_10
+          MIN_VERSION_ENV_NAME="HATCH_PYTHON_SOURCE_PYPY${MIN_PYTHON_VERSION_SHORT//./\_}"
+          MAX_VERSION_ENV_NAME="HATCH_PYTHON_SOURCE_PYPY${MAX_PYTHON_VERSION_SHORT//./\_}"
+
+          # Set the hatch enviornment variable for the python distribution
+          echo "${MIN_VERSION_ENV_NAME}=${min_version_path}" >> $GITHUB_ENV
+          echo "${MAX_VERSION_ENV_NAME}=${max_version_path}" >> $GITHUB_ENV
+        else if [ "${{ steps.test-matrix-present.outputs.matrix-present }}" == "false" ]; then
+          echo "HATCH_PYTHON_PATH=${{ steps.hatch-setup.outputs.hatch-python-path }}" >> $GITHUB_ENV
+        fi
 
     - name: Install Dependencies
       shell: bash

--- a/.github/actions/hatch-setup/action.yml
+++ b/.github/actions/hatch-setup/action.yml
@@ -86,13 +86,27 @@ runs:
         hatch env create hatch-test.py${{ inputs.min-python-version }}
         hatch env create hatch-test.py${{ inputs.max-python-version }}
 
+    - name: Install Dependencies for default python version
+      shell: bash
+      if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'false'
+      run: |
+        hatch run pip install --upgrade pip
+        hatch run pip install twine pytest pytest-cov
+
+    - name: Install Dependencies for test matrix python version
+      shell: bash
+      if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'true'
+      run: |
+        hatch run hatch-test.py${{ inputs.min-python-version }}:pip install --upgrade pip
+        hatch run hatch-test.py${{ inputs.max-python-version }}:pip install --upgrade pip
+        hatch run hatch-test.py${{ inputs.min-python-version }}:pip install twine pytest pytest-cov
+        hatch run hatch-test.py${{ inputs.max-python-version }}:pip install twine pytest pytest-cov
+
     - name: Install Requirements.txt Dependencies for default python version
       shell: bash
       if: hashFiles('requirements.txt') != '' && steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'false'
       run: |
-        hatch run pip install --upgrade pip
         hatch run pip install --upgrade -r requirements.txt
-        hatch run pip install twine pytest pytest-cov
 
     - name: Install Requirements.txt Dependencies for test matrix python version
       shell: bash

--- a/.github/actions/hatch-setup/action.yml
+++ b/.github/actions/hatch-setup/action.yml
@@ -88,6 +88,8 @@ runs:
           echo "Min Version Path: $min_version_path"
           echo "Max Version Path: $max_version_path"
 
+          hatch python show
+
           # Set hatch enviornment variable name for python Distribution eg. HATCH_PYTHON_SOURCE_PYPY3_10
           MIN_VERSION_ENV_NAME="HATCH_PYTHON_SOURCE_PYPY${MIN_PYTHON_VERSION_SHORT//./\_}"
           MAX_VERSION_ENV_NAME="HATCH_PYTHON_SOURCE_PYPY${MAX_PYTHON_VERSION_SHORT//./\_}"
@@ -107,6 +109,10 @@ runs:
 
     - name: Install Dependencies for test matrix
       shell: bash
+      with:
+        env:
+          HATCH_PYTHON_SOURCE_PYPY3_10: ${{ env.HATCH_PYTHON_SOURCE_PYPY3_10 }}
+          HATCH_PYTHON_SOURCE_PYPY3_12: ${{ env.HATCH_PYTHON_SOURCE_PYPY3_12 }}
       if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'true'
       run: |
         hatch env create hatch-test.py${{ inputs.min-python-version }}

--- a/.github/actions/hatch-setup/action.yml
+++ b/.github/actions/hatch-setup/action.yml
@@ -73,7 +73,7 @@ runs:
 
     - name: Install Python
       uses: actions/setup-python@v5
-      if: steps.test-matrix-present.outputs.matrix-present == 'true'
+      if: steps.test-matrix-present.outputs.matrix-present == 'false'
       with:
         python-version-file: pyproject.toml
         cache: "pip"

--- a/.github/actions/hatch-setup/action.yml
+++ b/.github/actions/hatch-setup/action.yml
@@ -63,7 +63,7 @@ runs:
 
     - name: Install Python Versions for Hatch Test Matrix
       id: setup-python
-      if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'true'
+      if: steps.test-matrix-present.outputs.matrix-present == 'true'
       uses: actions/setup-python@v5.5.0
       with:
         python-version: |
@@ -74,7 +74,7 @@ runs:
 
     - name: Install Python Version from pyproject.toml
       id: setup-python-default
-      if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'false'
+      if: steps.test-matrix-present.outputs.matrix-present == 'false'
       uses: actions/setup-python@v5.5.0
       with:
         python-version-file: "pyproject.toml"

--- a/.github/actions/hatch-setup/action.yml
+++ b/.github/actions/hatch-setup/action.yml
@@ -109,12 +109,13 @@ runs:
 
     - name: Install Dependencies for test matrix
       shell: bash
-      with:
-        env:
-          HATCH_PYTHON_SOURCE_PYPY3_10: ${{ env.HATCH_PYTHON_SOURCE_PYPY3_10 }}
-          HATCH_PYTHON_SOURCE_PYPY3_12: ${{ env.HATCH_PYTHON_SOURCE_PYPY3_12 }}
       if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'true'
       run: |
+        echo "CPU Information:"
+        cat /proc/cpuinfo
+        echo "Number of CPU Cores:"
+        nproc
+        echo "-------------------"
         hatch env create hatch-test.py${{ inputs.min-python-version }}
         hatch env create hatch-test.py${{ inputs.max-python-version }}
 

--- a/.github/actions/hatch-setup/action.yml
+++ b/.github/actions/hatch-setup/action.yml
@@ -92,7 +92,7 @@ runs:
 
     - name: Install Dependencies
       shell: bash
-      if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'false'
+      if: steps.cache.outputs.cache-hit != 'true'
       run: |
         hatch env create
 

--- a/.github/actions/hatch-setup/action.yml
+++ b/.github/actions/hatch-setup/action.yml
@@ -73,7 +73,7 @@ runs:
         cache-dependency-path: "pyproject.toml"
 
     - name: Install Hatch Matrix Python Versions
-      id: setup-python
+      id: setup-python-default
       if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'false'
       uses: hatch-community/setup-python@v5.5.0
       with:
@@ -112,10 +112,11 @@ runs:
     - name: Install Dependencies
       shell: bash
       env:
-        HATCH_PYTHON_PATH: ${{ steps.setup-python.outputs.pythonLocation }}
+        HATCH_PYTHON_PATH: ${{ steps.setup-python-default.outputs.pythonLocation }}
       if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'false'
       run: |
         hatch env create
+
     - name: Create Hatch Environment for Matrix Python Versions
       shell: bash
       env:
@@ -127,7 +128,7 @@ runs:
     - name: Install Dependencies for default python version
       shell: bash
       env:
-        HATCH_PYTHON_PATH: ${{ steps.setup-python.outputs.pythonLocation }}
+        HATCH_PYTHON_PATH: ${{ steps.setup-python-default.outputs.pythonLocation }}
       if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'false'
       run: |
         hatch run pip install --upgrade pip
@@ -135,6 +136,8 @@ runs:
 
     - name: Install Dependencies for test matrix python version
       shell: bash
+      env:
+        HATCH_PYTHON_PATH: ${{ steps.setup-python.outputs.pythonLocation }}
       if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'true'
       run: |
         hatch run hatch-test.py${{ inputs.min-python-version }}:pip install --upgrade pip

--- a/.github/actions/hatch-setup/action.yml
+++ b/.github/actions/hatch-setup/action.yml
@@ -104,7 +104,7 @@ runs:
 
     - name: Install Dependencies for default python version
       shell: bash
-      if: steps.cache.outputs.cache-hit != 'true' && steps.test-matrix-present.outputs.matrix-present == 'false'
+      if: steps.cache.outputs.cache-hit != 'true'
       run: |
         hatch run pip install --upgrade pip
         hatch run pip install twine pytest pytest-cov

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -6,12 +6,12 @@ on:
       min-python-version:
         type: string
         required: false
-        default: "3.10"
+        default: "3.10.16"
         description: "Minimum Python version to test against."
       max-python-version:
         type: string
         required: false
-        default: "3.12"
+        default: "3.13"
         description: "Maximum Python version to test against."
       whitesource_product_name:
         type: string
@@ -98,7 +98,7 @@ jobs:
 
       - name: Set up Hatch
         id: hatch-setup
-        uses: SolaceDev/solace-public-workflows/.github/actions/hatch-setup@main
+        uses: SolaceDev/solace-public-workflows/.github/actions/hatch-setup@python-install
         with:
           min-python-version: ${{ inputs.min-python-version }}
           max-python-version: ${{ inputs.max-python-version }}

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -6,7 +6,7 @@ on:
       min-python-version:
         type: string
         required: false
-        default: "3.10.16"
+        default: "3.10"
         description: "Minimum Python version to test against."
       max-python-version:
         type: string
@@ -98,7 +98,7 @@ jobs:
 
       - name: Set up Hatch
         id: hatch-setup
-        uses: SolaceDev/solace-public-workflows/.github/actions/hatch-setup@python-install
+        uses: SolaceDev/solace-public-workflows/.github/actions/hatch-setup@3.10
         with:
           min-python-version: ${{ inputs.min-python-version }}
           max-python-version: ${{ inputs.max-python-version }}

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Set up Hatch
         id: hatch-setup
-        uses: SolaceDev/solace-public-workflows/.github/actions/hatch-setup@3.10
+        uses: SolaceDev/solace-public-workflows/.github/actions/hatch-setup@main
         with:
           min-python-version: ${{ inputs.min-python-version }}
           max-python-version: ${{ inputs.max-python-version }}

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -216,13 +216,12 @@ jobs:
 
       - name: Verify Packages
         run: |
-          ls dist/*.tar.gz | xargs -n1 hatch run python -m twine check
-          ls dist/*.whl | xargs -n1 hatch run python -m twine check
+          ls dist/*.tar.gz | xargs -n1 hatch run hatch-test.py${{ inputs.max-python-version }}:python -m twine check
+          ls dist/*.whl | xargs -n1 hatch run hatch-test.py${{ inputs.max-python-version }}:python -m twine check
         shell: bash
 
       - name: Install Virtualenv for Whitesource Scan
         run: |
-          python -m pip install --upgrade pip
           pip install virtualenv
 
       - name: Run Whitesource Scan

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -216,8 +216,8 @@ jobs:
 
       - name: Verify Packages
         run: |
-          ls dist/*.tar.gz | xargs -n1 hatch run hatch-test.py${{ inputs.max-python-version }}:python -m twine check
-          ls dist/*.whl | xargs -n1 hatch run hatch-test.py${{ inputs.max-python-version }}:python -m twine check
+          ls dist/*.tar.gz | xargs -n1 hatch run python -m twine check
+          ls dist/*.whl | xargs -n1 hatch run python -m twine check
         shell: bash
 
       - name: Install Virtualenv for Whitesource Scan

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -222,6 +222,7 @@ jobs:
 
       - name: Install Virtualenv for Whitesource Scan
         run: |
+          python -m pip install --upgrade pip
           pip install virtualenv
 
       - name: Run Whitesource Scan


### PR DESCRIPTION
### What is the purpose of this change?

 - There is a bug in hatch where it fails to find the python version when we explicitly specify patch version as a requirement
 - Using setup-python allows us to have more version variants available

### How is this accomplished?

- Use setup-python 
- Export python-path from the action to hatch env variable
