### PR TITLE
DATAGO-99407: build hatch before running tests

### DIFF
--- a/.github/actions/hatch-lint-test/action.yml
+++ b/.github/actions/hatch-lint-test/action.yml
@@ -103,7 +103,6 @@ runs:
     - name: Build
       shell: bash
       run: |
-        hatch build
         hatch dep show requirements > requirements.txt
 
     - name: Verify Packages

--- a/.github/actions/hatch-setup/action.yml
+++ b/.github/actions/hatch-setup/action.yml
@@ -131,3 +131,8 @@ runs:
       run: |
         hatch run hatch-test.py${{ inputs.min-python-version }}:pip install --upgrade -r requirements.txt
         hatch run hatch-test.py${{ inputs.max-python-version }}:pip install --upgrade -r requirements.txt
+
+    - name: Build Hatch Package
+      shell: bash
+      run: |
+        hatch build

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -211,7 +211,6 @@ jobs:
       - name: Build
         shell: bash
         run: |
-          hatch build
           hatch dep show requirements > requirements.txt
 
       - name: Verify Packages


### PR DESCRIPTION
### What is the purpose of this change?

 Run the build before tests
 
 This allows us to install custom build hooks for hatch in each repo individually
