### PR TITLE
Fix GITHUB_SHA reference in CI workflow

### DIFF
--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -327,7 +327,7 @@ jobs:
           FAIL_IF_POLICY_VIOLATIONS_FOUND: "True"
           GH_ORG: ${{ github.repository_owner }}
           GH_REPO: ${{ github.event.repository.name }}
-          GITHUB_SHA: ${{ github.event.pull_request.head.sha }}
+          GH_SHA: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           STATUS_CHECK: "True"
         with:


### PR DESCRIPTION
### What is the purpose of this change?

- Fix reference to GITHUB_SHA variable

<!--start_gitstream_placeholder-->
### ✨ PR Description
### What is the purpose of this change?

Fix environment variable name in CI workflow to properly reference commit SHA for pull requests

### How is this accomplished?

- Renamed `GITHUB_SHA` environment variable to `GH_SHA` in the GitHub Actions workflow to maintain consistency with other environment variables (`GH_ORG`, `GH_REPO`) while preserving the reference to the pull request head SHA

### Anything reviews should focus on/be aware of?

- Verify that any scripts or tools consuming this environment variable have been updated or can handle this renamed variable
- Confirm that this change doesn't break the policy violation checking functionality that uses this SHA reference

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
