### PR TITLE
DATAGO-109185: Add dynamoDB query functionality to cicd helper 

### DIFF
--- a/.github/actions/cicd-helper/action.yaml
+++ b/.github/actions/cicd-helper/action.yaml
@@ -73,7 +73,7 @@ inputs:
 
 runs:
   using: docker
-  image: docker://ghcr.io/solacedev/maas-build-actions:missed_cicd_helper
+  image: docker://ghcr.io/solacedev/maas-build-actions:master
   entrypoint: /bin/sh
   args:
     - -c


### PR DESCRIPTION
### ✨ PR Description
### What is the purpose of this change?

Add DynamoDB field retrieval functionality to the CI/CD helper action to enable fetching specific field values or sections from DynamoDB items

### How is this accomplished?

- Add new input parameters to support the `get_item_value_from_dynamodb` operation:
  - `ddb_field_path`: Path to the field to retrieve (dot notation)
  - `ddb_output_name`: Name for the output variable 
  - `ddb_return_section`: Flag to return entire JSON section or single value
- Update Docker image reference to use the `missed_cicd_helper` branch image
- Add environment variable exports for the new parameters
- Add debug logging for the new parameters

### Anything reviews should focus on/be aware of?

- The Docker image reference has changed from `master` to `missed_cicd_helper` branch
- Verify that the new parameters are correctly passed to the underlying Python script
- Consider if documentation updates are needed for the new DynamoDB field retrieval feature

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
