### PR TITLE
chore: make slack channel optional for cicd helper action

### DIFF
--- a/.github/actions/cicd-helper/action.yaml
+++ b/.github/actions/cicd-helper/action.yaml
@@ -15,7 +15,7 @@ inputs:
     required: false
   slack_channel:
     description: Slack channel ID (e.g., G015384QZAB)
-    required: true
+    required: false
   thread_ts:
     description: Slack thread timestamp (for thread updates)
     required: false


### PR DESCRIPTION
This pull request makes a minor change to the GitHub Actions workflow configuration. The `slack_channel` input is no longer required, making it optional for workflows that use this action.### What is the purpose of this change?

    ...

### How is this accomplished?

    ...

### Anything reviews should focus on/be aware of?

    ...
