### PR TITLE
feat(DATAGO-128400): capture all commits between releases in Guardian Slack payload

### DIFF
--- a/.github/actions/sca/fossa-scan/action.yaml
+++ b/.github/actions/sca/fossa-scan/action.yaml
@@ -162,12 +162,15 @@ runs:
             COMMIT_MESSAGE="${BETWEEN_COMMITS} | ${COMMIT_MESSAGE}"
           fi
         fi
+        # BUILD_URL: full link to this workflow run for Slack notification deep-linking
+        BUILD_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
         SLACK_JSON=$(jq -n \
           --argjson report true \
           --arg revision "$FOSSA_REVISION" \
           --arg branch "$PRODUCT_VERSION" \
           --arg commit_message "$COMMIT_MESSAGE" \
-          '{report: $report, revision: $revision, branch: $branch, commit_message: $commit_message}')
+          --arg build_url "$BUILD_URL" \
+          '{report: $report, revision: $revision, branch: $branch, commit_message: $commit_message, build_url: $build_url}')
 
         MAX_RETRIES=3
         RETRY_DELAY=5

--- a/.github/actions/sca/fossa-scan/action.yaml
+++ b/.github/actions/sca/fossa-scan/action.yaml
@@ -136,8 +136,10 @@ runs:
         #                   "chore(release): version bump root-1.8.74 [ci skip]"
         if echo "$COMMIT_MESSAGE" | grep -qE '^chore\(release\):'; then
           # Find the SHA of the previous release commit (skip HEAD, match first release line)
+          # Anchored to start of subject (^[^ ]+ matches the SHA) to avoid false matches
+          # where "chore(release):" appears mid-subject in a non-release commit.
           PREV_RELEASE_SHA=$(git log --skip=1 --format="%H %s" 2>/dev/null \
-            | awk '/chore\(release\):/{print $1; exit}')
+            | awk '/^[^ ]+ chore\(release\):/{print $1; exit}')
 
           if [ -n "$PREV_RELEASE_SHA" ]; then
             # Collect all non-release commit subjects between the two release commits:
@@ -147,15 +149,16 @@ runs:
             #     -v  invert match (exclude lines that match)
             #     -E  extended regex
             #     ^chore\(release\):  same pattern as above
+            # awk join inserts " | " only between records, preserving any literal "|"
+            # characters that may exist inside individual commit subjects.
             BETWEEN_COMMITS=$(git log --skip=1 --pretty=%s "${PREV_RELEASE_SHA}..HEAD" 2>/dev/null \
               | grep -vE '^chore\(release\):' \
-              | tr '\n' '|' | sed 's/|$//; s/|/ | /g')
-            # tr '\n' '|'      joins lines with a pipe character
-            # s/|$//           removes the trailing pipe left by tr
-            # s/|/ | /g        pads every pipe into a readable " | " separator
+              | awk 'NR==1 {printf "%s", $0; next} {printf " | %s", $0} END {printf "\n"}')
           else
-            # No prior release found (first release or shallow clone) — grab the previous commit
-            BETWEEN_COMMITS=$(git log -2 --pretty=%s 2>/dev/null | tail -1)
+            # No prior release found (first release or shallow clone) — grab the previous commit.
+            # sed -n '2p' prints only the 2nd log line; returns empty on a single-commit history
+            # (e.g. fetch-depth: 1), avoiding a duplicate of HEAD in the payload.
+            BETWEEN_COMMITS=$(git log -2 --pretty=%s 2>/dev/null | sed -n '2p')
           fi
 
           if [ -n "$BETWEEN_COMMITS" ]; then

--- a/.github/actions/sca/fossa-scan/action.yaml
+++ b/.github/actions/sca/fossa-scan/action.yaml
@@ -122,6 +122,46 @@ runs:
         if [ -z "$COMMIT_MESSAGE" ]; then
           COMMIT_MESSAGE=$(git log -1 --pretty=%s 2>/dev/null || echo "")
         fi
+
+        # If head commit is a release commit, capture all commits since the previous release
+        # to surface Jira issue IDs from PR titles merged in this release window.
+        #
+        # Release commit pattern: ^chore\(release\):
+        #   ^            - must be at the start of the subject line
+        #   chore        - conventional commit type
+        #   \(release\)  - escaped parens around the release scope
+        #   :            - conventional commit delimiter
+        #
+        # Examples matched: "chore(release): 1.2.3"
+        #                   "chore(release): version bump root-1.8.74 [ci skip]"
+        if echo "$COMMIT_MESSAGE" | grep -qE '^chore\(release\):'; then
+          # Find the SHA of the previous release commit (skip HEAD, match first release line)
+          PREV_RELEASE_SHA=$(git log --skip=1 --format="%H %s" 2>/dev/null \
+            | awk '/chore\(release\):/{print $1; exit}')
+
+          if [ -n "$PREV_RELEASE_SHA" ]; then
+            # Collect all non-release commit subjects between the two release commits:
+            #   --skip=1                   skips HEAD (the current release commit)
+            #   PREV_RELEASE_SHA..HEAD     commits after the previous release up to HEAD
+            #   grep -vE '^chore\(release\):'  strips any intermediate release commits
+            #     -v  invert match (exclude lines that match)
+            #     -E  extended regex
+            #     ^chore\(release\):  same pattern as above
+            BETWEEN_COMMITS=$(git log --skip=1 --pretty=%s "${PREV_RELEASE_SHA}..HEAD" 2>/dev/null \
+              | grep -vE '^chore\(release\):' \
+              | tr '\n' '|' | sed 's/|$//; s/|/ | /g')
+            # tr '\n' '|'      joins lines with a pipe character
+            # s/|$//           removes the trailing pipe left by tr
+            # s/|/ | /g        pads every pipe into a readable " | " separator
+          else
+            # No prior release found (first release or shallow clone) — grab the previous commit
+            BETWEEN_COMMITS=$(git log -2 --pretty=%s 2>/dev/null | tail -1)
+          fi
+
+          if [ -n "$BETWEEN_COMMITS" ]; then
+            COMMIT_MESSAGE="${BETWEEN_COMMITS} | ${COMMIT_MESSAGE}"
+          fi
+        fi
         SLACK_JSON=$(jq -n \
           --argjson report true \
           --arg revision "$FOSSA_REVISION" \


### PR DESCRIPTION
## Summary

- When the FOSSA scan triggers on a release commit (`chore(release): ...`), the Guardian Slack payload `commit_message` field now collects **all PR subjects merged since the previous release plus the release commit itself** instead of just the release version bump
- Jira issue IDs from PR titles (e.g. `DATAGO-XXXX: ...`) are surfaced in the Slack notification, giving the security team meaningful context about what changed
- Falls back gracefully when no prior release exists (first release or shallow clone with `fetch-depth: 1`)
- Added `build_url` to the Guardian Slack payload — a direct link to the GitHub Actions run that produced the scan result

## How it works

1. Detects release commits via `^chore\(release\):` regex on the HEAD subject
2. Finds the SHA of the previous release commit via `git log --skip=1`, anchored to the start of the subject line to avoid false matches
3. Collects all non-release subjects in `PREV_RELEASE_SHA..HEAD` using `git log --skip=1`
4. Joins them with awk (preserving any literal `|` in commit subjects), then appends the release commit as the final entry
5. Constructs `build_url` from reserved GitHub Actions env vars: `$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID`

**Example Slack payload `commit_message` — single PR:**
```
DATAGO-125090: Bridges Check Enhancements (#4842) | chore(release): 0.0.1671
```

**Example Slack payload `commit_message` — multiple PRs:**
```
uqamar/DATAGO-126843: vulnerability detected (#4812) | DATAGO-127942: Fix DT permission (#4806) | chore(release): 0.0.1657
```

**Example Slack payload `build_url`:**
```
https://github.com/SolaceDev/maas-gateway/actions/runs/12345678901
```

The release commit is always preserved — if nothing exists between two releases, `commit_message` falls back to just the release subject unchanged.

## Test plan

Verified against `maas-gateway` and `maas-core` repos across three scenarios:

- [x] **Single PR between releases** — correctly prepends Jira commit to release subject
- [x] **Multiple PRs between releases** — all subjects joined with ` | `, release commit appended
- [x] **Consecutive releases (no PR between)** — falls through gracefully, release subject preserved
- [x] **Shallow clone fallback** — `sed -n '2p'` returns empty on single-commit history, no duplication
- [x] **Non-release commits** — existing single-commit path unchanged
- [x] `build_url` resolves correctly using reserved GitHub Actions env vars (works on GitHub.com and GHES)

## Copilot review fixes

- Anchored awk release-commit pattern to start of subject (`^[^ ]+ chore\(release\):`) to prevent false matches
- Replaced `tr | sed` join with awk join to preserve literal `|` characters inside commit subjects
- Replaced `tail -1` with `sed -n '2p'` in shallow-clone fallback to avoid duplicating HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)