### PR TITLE
ci(DATAGO-131317): dynamic GitHub org for maas-build-actions image pull

### DIFF
--- a/.github/actions/cicd-helper/action.yaml
+++ b/.github/actions/cicd-helper/action.yaml
@@ -176,6 +176,6 @@ runs:
           -v "${GITHUB_WORKSPACE}:/github/workspace" \
           -v "${RUNNER_TEMP}:${RUNNER_TEMP}" \
           --workdir /github/workspace \
-          "ghcr.io/${OWNER}/maas-build-actions:master" \
+          "ghcr.io/${OWNER}/maas-build-actions@sha256:6182de169f2016eeab994aed8626edb1295d43720cd4485d43301d8e6b5c35fc" \
           /bin/sh -c 'source /maas-build-actions/venv/bin/activate && $RC_PYTHON $RC_HELPER_SCRIPT'
 

--- a/.github/actions/cicd-helper/action.yaml
+++ b/.github/actions/cicd-helper/action.yaml
@@ -90,82 +90,87 @@ inputs:
     required: false
 
 runs:
-  using: docker
-  image: docker://ghcr.io/${{ github.repository_owner }}/maas-build-actions:master
-  entrypoint: /bin/sh
-  args:
-    - -c
-    - |
-      export SLACK_TOKEN="$INPUT_SLACK_TOKEN"
-      export SLACK_CHANNEL="$INPUT_SLACK_CHANNEL"
-      export RC_STEP="$INPUT_RC_STEP"
-      export RC_PYTHON="python3"
-      export RC_HELPER_SCRIPT="/maas-build-actions/scripts/cicd-helper/cicd-helper.py"
-      if [ -n "$INPUT_THREAD_TS" ]; then export THREAD_TS="$INPUT_THREAD_TS"; fi
-      if [ -n "$INPUT_MESSAGE" ]; then export MESSAGE="$INPUT_MESSAGE"; fi
-      if [ -n "$INPUT_THREAD_MESSAGE" ]; then export THREAD_MESSAGE="$INPUT_THREAD_MESSAGE"; fi
-      if [ -n "$INPUT_MESSAGE_HEADER" ]; then export MESSAGE_HEADER="$INPUT_MESSAGE_HEADER"; fi
-      if [ -n "$INPUT_NEW_MESSAGE_HEADER" ]; then export NEW_MESSAGE_HEADER="$INPUT_NEW_MESSAGE_HEADER"; fi
-      if [ -n "$INPUT_CHANGE_LOG_HEADER_METADATA" ]; then export CHANGE_LOG_HEADER_METADATA="$INPUT_CHANGE_LOG_HEADER_METADATA"; fi
-      if [ -n "$INPUT_PREVIOUS_MESSAGE" ]; then export PREVIOUS_MESSAGE="$INPUT_PREVIOUS_MESSAGE"; fi
-      if [ -n "$INPUT_REPO_NAME" ]; then export REPO_NAME="$INPUT_REPO_NAME"; fi
-      if [ -n "$INPUT_DEPLOYED_REF" ]; then export DEPLOYED_REF="$INPUT_DEPLOYED_REF"; fi
-      if [ -n "$INPUT_CANDIDATE_REF" ]; then export CANDIDATE_REF="$INPUT_CANDIDATE_REF"; fi
-      if [ -n "$INPUT_CONTRIBUTORS_RAW_LIST" ]; then export CONTRIBUTORS_RAW_LIST="$INPUT_CONTRIBUTORS_RAW_LIST"; fi
-      if [ -n "$INPUT_DDB_ITEM_TO_BE_ADDED" ]; then export DDB_ITEM_TO_BE_ADDED="$INPUT_DDB_ITEM_TO_BE_ADDED"; fi
-      if [ -n "$INPUT_DDB_TABLE_NAME" ]; then export DDB_TABLE_NAME="$INPUT_DDB_TABLE_NAME"; fi
-      if [ -n "$INPUT_DDB_PARTITION_KEY" ]; then export DDB_PARTITION_KEY="$INPUT_DDB_PARTITION_KEY"; fi
-      if [ -n "$INPUT_DDB_SORT_KEY" ]; then export DDB_SORT_KEY="$INPUT_DDB_SORT_KEY"; fi
-      if [ -n "$INPUT_DDB_QUERY_JSON" ]; then export DDB_QUERY_JSON="$INPUT_DDB_QUERY_JSON"; fi
-      if [ -n "$INPUT_DDB_EXISTS_OUTPUT" ]; then export DDB_EXISTS_OUTPUT="$INPUT_DDB_EXISTS_OUTPUT"; fi
-      if [ -n "$INPUT_DDB_FIELD_PATH" ]; then export DDB_FIELD_PATH="$INPUT_DDB_FIELD_PATH"; fi
-      if [ -n "$INPUT_DDB_OUTPUT_NAME" ]; then export DDB_OUTPUT_NAME="$INPUT_DDB_OUTPUT_NAME"; fi
-      if [ -n "$INPUT_DDB_RETURN_SECTION" ]; then export DDB_RETURN_SECTION="$INPUT_DDB_RETURN_SECTION"; fi
-      if [ -n "$INPUT_THREAD_MESSAGE_TS" ]; then export THREAD_MESSAGE_TS="$INPUT_THREAD_MESSAGE_TS"; fi
-      if [ -n "$INPUT_NEW_THREAD_MESSAGE" ]; then export NEW_THREAD_MESSAGE="$INPUT_NEW_THREAD_MESSAGE"; fi
-      if [ -n "$INPUT_DDB_TABLE_INDEX_NAME" ]; then export DDB_TABLE_INDEX_NAME="$INPUT_DDB_TABLE_INDEX_NAME"; fi
-      if [ -n "$INPUT_DDB_INDEX_FIELD_NAME" ]; then export DDB_INDEX_FIELD_NAME="$INPUT_DDB_INDEX_FIELD_NAME"; fi
-      if [ -n "$INPUT_DDB_INDEX_FIELD_VALUE" ]; then export DDB_INDEX_FIELD_VALUE="$INPUT_DDB_INDEX_FIELD_VALUE"; fi
+  using: composite
+  steps:
+    - name: Run RC Helper
+      shell: bash
+      run: |
+        OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
 
+        # Map INPUT_* vars to the names the container scripts expect, then pass
+        # each to docker via -e KEY (by reference from the current process env).
+        # This is the safer approach: secrets are never written to disk and never
+        # appear as command-line argument values visible in the process list.
+        export SLACK_TOKEN="${INPUT_SLACK_TOKEN}"
+        export SLACK_CHANNEL="${INPUT_SLACK_CHANNEL}"
+        export RC_STEP="${INPUT_RC_STEP}"
+        export RC_PYTHON="python3"
+        export RC_HELPER_SCRIPT="/maas-build-actions/scripts/cicd-helper/cicd-helper.py"
+        [ -n "${INPUT_THREAD_TS}" ]               && export THREAD_TS="${INPUT_THREAD_TS}"
+        [ -n "${INPUT_MESSAGE}" ]                  && export MESSAGE="${INPUT_MESSAGE}"
+        [ -n "${INPUT_THREAD_MESSAGE}" ]           && export THREAD_MESSAGE="${INPUT_THREAD_MESSAGE}"
+        [ -n "${INPUT_MESSAGE_HEADER}" ]           && export MESSAGE_HEADER="${INPUT_MESSAGE_HEADER}"
+        [ -n "${INPUT_NEW_MESSAGE_HEADER}" ]       && export NEW_MESSAGE_HEADER="${INPUT_NEW_MESSAGE_HEADER}"
+        [ -n "${INPUT_CHANGE_LOG_HEADER_METADATA}" ] && export CHANGE_LOG_HEADER_METADATA="${INPUT_CHANGE_LOG_HEADER_METADATA}"
+        [ -n "${INPUT_PREVIOUS_MESSAGE}" ]         && export PREVIOUS_MESSAGE="${INPUT_PREVIOUS_MESSAGE}"
+        [ -n "${INPUT_REPO_NAME}" ]                && export REPO_NAME="${INPUT_REPO_NAME}"
+        [ -n "${INPUT_DEPLOYED_REF}" ]             && export DEPLOYED_REF="${INPUT_DEPLOYED_REF}"
+        [ -n "${INPUT_CANDIDATE_REF}" ]            && export CANDIDATE_REF="${INPUT_CANDIDATE_REF}"
+        [ -n "${INPUT_CONTRIBUTORS_RAW_LIST}" ]    && export CONTRIBUTORS_RAW_LIST="${INPUT_CONTRIBUTORS_RAW_LIST}"
+        [ -n "${INPUT_DDB_ITEM_TO_BE_ADDED}" ]     && export DDB_ITEM_TO_BE_ADDED="${INPUT_DDB_ITEM_TO_BE_ADDED}"
+        [ -n "${INPUT_DDB_TABLE_NAME}" ]           && export DDB_TABLE_NAME="${INPUT_DDB_TABLE_NAME}"
+        [ -n "${INPUT_DDB_PARTITION_KEY}" ]        && export DDB_PARTITION_KEY="${INPUT_DDB_PARTITION_KEY}"
+        [ -n "${INPUT_DDB_SORT_KEY}" ]             && export DDB_SORT_KEY="${INPUT_DDB_SORT_KEY}"
+        [ -n "${INPUT_DDB_QUERY_JSON}" ]           && export DDB_QUERY_JSON="${INPUT_DDB_QUERY_JSON}"
+        [ -n "${INPUT_DDB_EXISTS_OUTPUT}" ]        && export DDB_EXISTS_OUTPUT="${INPUT_DDB_EXISTS_OUTPUT}"
+        [ -n "${INPUT_DDB_FIELD_PATH}" ]           && export DDB_FIELD_PATH="${INPUT_DDB_FIELD_PATH}"
+        [ -n "${INPUT_DDB_OUTPUT_NAME}" ]          && export DDB_OUTPUT_NAME="${INPUT_DDB_OUTPUT_NAME}"
+        [ -n "${INPUT_DDB_RETURN_SECTION}" ]       && export DDB_RETURN_SECTION="${INPUT_DDB_RETURN_SECTION}"
+        [ -n "${INPUT_THREAD_MESSAGE_TS}" ]        && export THREAD_MESSAGE_TS="${INPUT_THREAD_MESSAGE_TS}"
+        [ -n "${INPUT_NEW_THREAD_MESSAGE}" ]       && export NEW_THREAD_MESSAGE="${INPUT_NEW_THREAD_MESSAGE}"
+        [ -n "${INPUT_DDB_TABLE_INDEX_NAME}" ]     && export DDB_TABLE_INDEX_NAME="${INPUT_DDB_TABLE_INDEX_NAME}"
+        [ -n "${INPUT_DDB_INDEX_FIELD_NAME}" ]     && export DDB_INDEX_FIELD_NAME="${INPUT_DDB_INDEX_FIELD_NAME}"
+        [ -n "${INPUT_DDB_INDEX_FIELD_VALUE}" ]    && export DDB_INDEX_FIELD_VALUE="${INPUT_DDB_INDEX_FIELD_VALUE}"
+        export AWS_REGION="${INPUT_AWS_REGION:-us-east-1}"
 
-
-      # Set AWS_REGION, default to us-east-1 if not set
-      if [ -n "$INPUT_AWS_REGION" ]; then
-        export AWS_REGION="$INPUT_AWS_REGION"
-      else
-        export AWS_REGION="us-east-1"
-      fi
-
-      echo "Debug: Inputs:"
-      echo "RC_STEP: $RC_STEP"
-      echo "SLACK_TOKEN: [REDACTED]"
-      echo "SLACK_CHANNEL: $SLACK_CHANNEL"
-      echo "THREAD_TS: $THREAD_TS"
-      echo "MESSAGE: $MESSAGE"
-      echo "THREAD_MESSAGE: $THREAD_MESSAGE"
-      echo "NEW_MESSAGE_HEADER: $NEW_MESSAGE_HEADER"
-      echo "CHANGE_LOG_HEADER_METADATA: $CHANGE_LOG_HEADER_METADATA"
-      echo "PREVIOUS_MESSAGE: $PREVIOUS_MESSAGE"
-      echo "REPO_NAME: $REPO_NAME"
-      echo "DEPLOYED_REF: $DEPLOYED_REF"
-      echo "CANDIDATE_REF: $CANDIDATE_REF"
-      echo "DDB_ITEM_TO_BE_ADDED: $DDB_ITEM_TO_BE_ADDED"
-      echo "DDB_TABLE_NAME: $DDB_TABLE_NAME"
-      echo "DDB_PARTITION_KEY: $DDB_PARTITION_KEY"
-      echo "DDB_SORT_KEY: $DDB_SORT_KEY"
-      echo "DDB_QUERY_JSON: $DDB_QUERY_JSON"
-      echo "DDB_EXISTS_OUTPUT: $DDB_EXISTS_OUTPUT"
-      echo "CONTRIBUTORS_RAW_LIST: $CONTRIBUTORS_RAW_LIST"
-      echo "DDB_FIELD_PATH: $DDB_FIELD_PATH"
-      echo "DDB_OUTPUT_NAME: $DDB_OUTPUT_NAME"
-      echo "DDB_RETURN_SECTION: $DDB_RETURN_SECTION"
-      echo "AWS_REGION: $AWS_REGION"
-      echo "THREAD_MESSAGE_TS: $THREAD_MESSAGE_TS"
-      echo "NEW_THREAD_MESSAGE: $NEW_THREAD_MESSAGE"
-      echo "DDB_TABLE_INDEX_NAME: $DDB_TABLE_INDEX_NAME"
-      echo "DDB_INDEX_FIELD_NAME: $DDB_INDEX_FIELD_NAME"
-      echo "DDB_INDEX_FIELD_VALUE: $DDB_INDEX_FIELD_VALUE"
-
-      source /maas-build-actions/venv/bin/activate
-      $RC_PYTHON $RC_HELPER_SCRIPT
+        docker run --rm \
+          -e SLACK_TOKEN \
+          -e SLACK_CHANNEL \
+          -e RC_STEP \
+          -e RC_PYTHON \
+          -e RC_HELPER_SCRIPT \
+          -e THREAD_TS \
+          -e MESSAGE \
+          -e THREAD_MESSAGE \
+          -e MESSAGE_HEADER \
+          -e NEW_MESSAGE_HEADER \
+          -e CHANGE_LOG_HEADER_METADATA \
+          -e PREVIOUS_MESSAGE \
+          -e REPO_NAME \
+          -e DEPLOYED_REF \
+          -e CANDIDATE_REF \
+          -e CONTRIBUTORS_RAW_LIST \
+          -e DDB_ITEM_TO_BE_ADDED \
+          -e DDB_TABLE_NAME \
+          -e DDB_PARTITION_KEY \
+          -e DDB_SORT_KEY \
+          -e DDB_QUERY_JSON \
+          -e DDB_EXISTS_OUTPUT \
+          -e DDB_FIELD_PATH \
+          -e DDB_OUTPUT_NAME \
+          -e DDB_RETURN_SECTION \
+          -e THREAD_MESSAGE_TS \
+          -e NEW_THREAD_MESSAGE \
+          -e DDB_TABLE_INDEX_NAME \
+          -e DDB_INDEX_FIELD_NAME \
+          -e DDB_INDEX_FIELD_VALUE \
+          -e AWS_REGION \
+          -e GITHUB_REPOSITORY \
+          -e GITHUB_OUTPUT \
+          -e GITHUB_STEP_SUMMARY \
+          -v "${GITHUB_WORKSPACE}:/github/workspace" \
+          -v "${RUNNER_TEMP}:${RUNNER_TEMP}" \
+          --workdir /github/workspace \
+          "ghcr.io/${OWNER}/maas-build-actions:master" \
+          /bin/sh -c 'source /maas-build-actions/venv/bin/activate && $RC_PYTHON $RC_HELPER_SCRIPT'
 

--- a/.github/actions/cicd-helper/action.yaml
+++ b/.github/actions/cicd-helper/action.yaml
@@ -97,6 +97,11 @@ runs:
       run: |
         OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
 
+        # Authenticate to GHCR using the calling workflow's token so internal
+        # org packages can be pulled. runs.using: docker did this automatically;
+        # with composite + docker run we handle it explicitly.
+        echo "${{ github.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
         # Map INPUT_* vars to the names the container scripts expect, then pass
         # each to docker via -e KEY (by reference from the current process env).
         # This is the safer approach: secrets are never written to disk and never

--- a/.github/actions/cicd-helper/action.yaml
+++ b/.github/actions/cicd-helper/action.yaml
@@ -91,7 +91,7 @@ inputs:
 
 runs:
   using: docker
-  image: docker://ghcr.io/solacedev/maas-build-actions:master
+  image: docker://ghcr.io/${{ github.repository_owner }}/maas-build-actions:master
   entrypoint: /bin/sh
   args:
     - -c

--- a/.github/actions/fossa-guard/action.yaml
+++ b/.github/actions/fossa-guard/action.yaml
@@ -86,67 +86,79 @@ inputs:
     default: "false"
 
 runs:
-  using: docker
-  image: docker://ghcr.io/${{ github.repository_owner }}/maas-build-actions:latest
-  entrypoint: /bin/sh
-  args:
-    - -c
-    - |
-      export FOSSA_API_KEY="$INPUT_FOSSA_API_KEY"
-      export FOSSA_PROJECT_ID="$INPUT_FOSSA_PROJECT_ID"
-      export FOSSA_CATEGORY="$INPUT_FOSSA_CATEGORY"
-      if [ -n "$INPUT_FOSSA_MODE" ]; then export FOSSA_MODE="$INPUT_FOSSA_MODE"; fi
-      if [ -n "$INPUT_BLOCK_ON" ]; then export BLOCK_ON="$INPUT_BLOCK_ON"; fi
-      if [ -n "$INPUT_FOSSA_BRANCH" ]; then export FOSSA_BRANCH="$INPUT_FOSSA_BRANCH"; fi
-      if [ -n "$INPUT_FOSSA_REVISION" ]; then export FOSSA_REVISION="$INPUT_FOSSA_REVISION"; fi
-      if [ -n "$INPUT_FOSSA_REVISION_SCAN_ID" ]; then export FOSSA_REVISION_SCAN_ID="$INPUT_FOSSA_REVISION_SCAN_ID"; fi
-      if [ -n "$INPUT_FOSSA_RELEASE" ]; then export FOSSA_RELEASE="$INPUT_FOSSA_RELEASE"; fi
-      if [ -n "$INPUT_FOSSA_RELEASE_SCAN_ID" ]; then export FOSSA_RELEASE_SCAN_ID="$INPUT_FOSSA_RELEASE_SCAN_ID"; fi
-      if [ -n "$INPUT_SLACK_TOKEN" ]; then export SLACK_TOKEN="$INPUT_SLACK_TOKEN"; fi
-      if [ -n "$INPUT_SLACK_CHANNEL" ]; then export SLACK_CHANNEL="$INPUT_SLACK_CHANNEL"; fi
-      if [ -n "$INPUT_SLACK_THREAD_TS" ]; then export SLACK_THREAD_TS="$INPUT_SLACK_THREAD_TS"; fi
-      if [ -n "$INPUT_GITHUB_REPOSITORY" ]; then export GITHUB_REPOSITORY="$INPUT_GITHUB_REPOSITORY"; fi
-      if [ -n "$INPUT_GITHUB_RUN_ID" ]; then export GITHUB_RUN_ID="$INPUT_GITHUB_RUN_ID"; fi
-      if [ -n "$INPUT_GITHUB_SERVER_URL" ]; then export GITHUB_SERVER_URL="$INPUT_GITHUB_SERVER_URL"; fi
-      if [ -n "$INPUT_GITHUB_TOKEN" ]; then export GITHUB_TOKEN="$INPUT_GITHUB_TOKEN"; fi
-      if [ -n "$INPUT_ENABLE_PR_COMMENT" ]; then export ENABLE_PR_COMMENT="$INPUT_ENABLE_PR_COMMENT"; fi
-      if [ -n "$INPUT_ENABLE_STATUS_CHECK" ]; then export ENABLE_STATUS_CHECK="$INPUT_ENABLE_STATUS_CHECK"; fi
-      if [ -n "$INPUT_STATUS_CHECK_NAME" ]; then export STATUS_CHECK_NAME="$INPUT_STATUS_CHECK_NAME"; fi
-      if [ -n "$INPUT_PR_COMMENT_MAX_VIOLATIONS" ]; then export PR_COMMENT_MAX_VIOLATIONS="$INPUT_PR_COMMENT_MAX_VIOLATIONS"; fi
-      if [ -n "$INPUT_ENABLE_DIFF_MODE" ]; then export ENABLE_DIFF_MODE="$INPUT_ENABLE_DIFF_MODE"; fi
-      if [ -n "$INPUT_DIFF_BASE_REVISION_SHA" ]; then export DIFF_BASE_REVISION_SHA="$INPUT_DIFF_BASE_REVISION_SHA"; fi
-      if [ -n "$INPUT_ENABLE_LICENSE_ENRICHMENT" ]; then export ENABLE_LICENSE_ENRICHMENT="$INPUT_ENABLE_LICENSE_ENRICHMENT"; fi
-      if [ -n "$INPUT_ENABLE_PRIVACY_MODE" ]; then export ENABLE_PRIVACY_MODE="$INPUT_ENABLE_PRIVACY_MODE"; fi
-      echo "Debug: Inputs:"
-      echo "FOSSA_API_KEY: [REDACTED]"
-      echo "FOSSA_PROJECT_ID: $FOSSA_PROJECT_ID"
-      echo "FOSSA_CATEGORY: $FOSSA_CATEGORY"
-      echo "FOSSA_MODE: $FOSSA_MODE"
-      echo "BLOCK_ON: $BLOCK_ON"
-      echo "FOSSA_BRANCH: $FOSSA_BRANCH"
-      echo "FOSSA_REVISION: $FOSSA_REVISION"
-      echo "FOSSA_REVISION_SCAN_ID: $FOSSA_REVISION_SCAN_ID"
-      echo "FOSSA_RELEASE: $FOSSA_RELEASE"
-      echo "FOSSA_RELEASE_SCAN_ID: $FOSSA_RELEASE_SCAN_ID"
-      echo "SLACK_TOKEN: [REDACTED]"
-      echo "SLACK_CHANNEL: $SLACK_CHANNEL"
-      echo "SLACK_THREAD_TS: $SLACK_THREAD_TS"
-      echo "GITHUB_REPOSITORY: $GITHUB_REPOSITORY"
-      echo "GITHUB_RUN_ID: $GITHUB_RUN_ID"
-      echo "GITHUB_SERVER_URL: $GITHUB_SERVER_URL"
-      echo "GITHUB_TOKEN: [REDACTED]"
-      echo "ENABLE_PR_COMMENT: $ENABLE_PR_COMMENT"
-      echo "ENABLE_STATUS_CHECK: $ENABLE_STATUS_CHECK"
-      echo "STATUS_CHECK_NAME: $STATUS_CHECK_NAME"
-      echo "PR_COMMENT_MAX_VIOLATIONS: $PR_COMMENT_MAX_VIOLATIONS"
-      echo "ENABLE_DIFF_MODE: $ENABLE_DIFF_MODE"
-      echo "DIFF_BASE_REVISION_SHA: $DIFF_BASE_REVISION_SHA"
-      echo "ENABLE_LICENSE_ENRICHMENT: $ENABLE_LICENSE_ENRICHMENT"
-      echo "ENABLE_PRIVACY_MODE: $ENABLE_PRIVACY_MODE"
-      echo "GITHUB_EVENT_NAME: $GITHUB_EVENT_NAME"
-      echo "GITHUB_REF: $GITHUB_REF"
-      echo "GITHUB_SHA: $GITHUB_SHA"
-      echo "GITHUB_HEAD_REF: $GITHUB_HEAD_REF"
-      echo "GITHUB_BASE_REF: $GITHUB_BASE_REF"
-      source /maas-build-actions/venv/bin/activate
-      python3 /maas-build-actions/scripts/fossa-guard/fossa_guard.py
+  using: composite
+  steps:
+    - name: Run Fossa Guard
+      shell: bash
+      run: |
+        OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+
+        # Map INPUT_* vars to the names the container scripts expect, then pass
+        # each to docker via -e KEY (by reference from the current process env).
+        # This is the safer approach: secrets are never written to disk and never
+        # appear as command-line argument values visible in the process list.
+        export FOSSA_API_KEY="${INPUT_FOSSA_API_KEY}"
+        export FOSSA_PROJECT_ID="${INPUT_FOSSA_PROJECT_ID}"
+        export FOSSA_CATEGORY="${INPUT_FOSSA_CATEGORY}"
+        [ -n "${INPUT_FOSSA_MODE}" ]              && export FOSSA_MODE="${INPUT_FOSSA_MODE}"
+        [ -n "${INPUT_BLOCK_ON}" ]                && export BLOCK_ON="${INPUT_BLOCK_ON}"
+        [ -n "${INPUT_FOSSA_BRANCH}" ]            && export FOSSA_BRANCH="${INPUT_FOSSA_BRANCH}"
+        [ -n "${INPUT_FOSSA_REVISION}" ]          && export FOSSA_REVISION="${INPUT_FOSSA_REVISION}"
+        [ -n "${INPUT_FOSSA_REVISION_SCAN_ID}" ]  && export FOSSA_REVISION_SCAN_ID="${INPUT_FOSSA_REVISION_SCAN_ID}"
+        [ -n "${INPUT_FOSSA_RELEASE}" ]           && export FOSSA_RELEASE="${INPUT_FOSSA_RELEASE}"
+        [ -n "${INPUT_FOSSA_RELEASE_SCAN_ID}" ]   && export FOSSA_RELEASE_SCAN_ID="${INPUT_FOSSA_RELEASE_SCAN_ID}"
+        [ -n "${INPUT_SLACK_TOKEN}" ]             && export SLACK_TOKEN="${INPUT_SLACK_TOKEN}"
+        [ -n "${INPUT_SLACK_CHANNEL}" ]           && export SLACK_CHANNEL="${INPUT_SLACK_CHANNEL}"
+        [ -n "${INPUT_SLACK_THREAD_TS}" ]         && export SLACK_THREAD_TS="${INPUT_SLACK_THREAD_TS}"
+        [ -n "${INPUT_GITHUB_REPOSITORY}" ]       && export GITHUB_REPOSITORY="${INPUT_GITHUB_REPOSITORY}"
+        [ -n "${INPUT_GITHUB_RUN_ID}" ]           && export GITHUB_RUN_ID="${INPUT_GITHUB_RUN_ID}"
+        [ -n "${INPUT_GITHUB_SERVER_URL}" ]       && export GITHUB_SERVER_URL="${INPUT_GITHUB_SERVER_URL}"
+        [ -n "${INPUT_GITHUB_TOKEN}" ]            && export GITHUB_TOKEN="${INPUT_GITHUB_TOKEN}"
+        [ -n "${INPUT_ENABLE_PR_COMMENT}" ]       && export ENABLE_PR_COMMENT="${INPUT_ENABLE_PR_COMMENT}"
+        [ -n "${INPUT_ENABLE_STATUS_CHECK}" ]     && export ENABLE_STATUS_CHECK="${INPUT_ENABLE_STATUS_CHECK}"
+        [ -n "${INPUT_STATUS_CHECK_NAME}" ]       && export STATUS_CHECK_NAME="${INPUT_STATUS_CHECK_NAME}"
+        [ -n "${INPUT_PR_COMMENT_MAX_VIOLATIONS}" ] && export PR_COMMENT_MAX_VIOLATIONS="${INPUT_PR_COMMENT_MAX_VIOLATIONS}"
+        [ -n "${INPUT_ENABLE_DIFF_MODE}" ]        && export ENABLE_DIFF_MODE="${INPUT_ENABLE_DIFF_MODE}"
+        [ -n "${INPUT_DIFF_BASE_REVISION_SHA}" ]  && export DIFF_BASE_REVISION_SHA="${INPUT_DIFF_BASE_REVISION_SHA}"
+        [ -n "${INPUT_ENABLE_LICENSE_ENRICHMENT}" ] && export ENABLE_LICENSE_ENRICHMENT="${INPUT_ENABLE_LICENSE_ENRICHMENT}"
+        [ -n "${INPUT_ENABLE_PRIVACY_MODE}" ]     && export ENABLE_PRIVACY_MODE="${INPUT_ENABLE_PRIVACY_MODE}"
+
+        docker run --rm \
+          -e FOSSA_API_KEY \
+          -e FOSSA_PROJECT_ID \
+          -e FOSSA_CATEGORY \
+          -e FOSSA_MODE \
+          -e BLOCK_ON \
+          -e FOSSA_BRANCH \
+          -e FOSSA_REVISION \
+          -e FOSSA_REVISION_SCAN_ID \
+          -e FOSSA_RELEASE \
+          -e FOSSA_RELEASE_SCAN_ID \
+          -e SLACK_TOKEN \
+          -e SLACK_CHANNEL \
+          -e SLACK_THREAD_TS \
+          -e GITHUB_REPOSITORY \
+          -e GITHUB_RUN_ID \
+          -e GITHUB_SERVER_URL \
+          -e GITHUB_TOKEN \
+          -e ENABLE_PR_COMMENT \
+          -e ENABLE_STATUS_CHECK \
+          -e STATUS_CHECK_NAME \
+          -e PR_COMMENT_MAX_VIOLATIONS \
+          -e ENABLE_DIFF_MODE \
+          -e DIFF_BASE_REVISION_SHA \
+          -e ENABLE_LICENSE_ENRICHMENT \
+          -e ENABLE_PRIVACY_MODE \
+          -e GITHUB_REF \
+          -e GITHUB_SHA \
+          -e GITHUB_HEAD_REF \
+          -e GITHUB_BASE_REF \
+          -e GITHUB_EVENT_NAME \
+          -e GITHUB_EVENT_PATH \
+          -e GITHUB_OUTPUT \
+          -e GITHUB_STEP_SUMMARY \
+          -v "${GITHUB_WORKSPACE}:/github/workspace" \
+          -v "${RUNNER_TEMP}:${RUNNER_TEMP}" \
+          --workdir /github/workspace \
+          "ghcr.io/${OWNER}/maas-build-actions:latest" \
+          /bin/sh -c 'source /maas-build-actions/venv/bin/activate && python3 /maas-build-actions/scripts/fossa-guard/fossa_guard.py'

--- a/.github/actions/fossa-guard/action.yaml
+++ b/.github/actions/fossa-guard/action.yaml
@@ -98,35 +98,37 @@ runs:
         # with composite + docker run we handle it explicitly.
         echo "${{ github.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
-        # Map INPUT_* vars to the names the container scripts expect, then pass
-        # each to docker via -e KEY (by reference from the current process env).
-        # This is the safer approach: secrets are never written to disk and never
-        # appear as command-line argument values visible in the process list.
-        export FOSSA_API_KEY="${INPUT_FOSSA_API_KEY}"
-        export FOSSA_PROJECT_ID="${INPUT_FOSSA_PROJECT_ID}"
-        export FOSSA_CATEGORY="${INPUT_FOSSA_CATEGORY}"
-        [ -n "${INPUT_FOSSA_MODE}" ]              && export FOSSA_MODE="${INPUT_FOSSA_MODE}"
-        [ -n "${INPUT_BLOCK_ON}" ]                && export BLOCK_ON="${INPUT_BLOCK_ON}"
-        [ -n "${INPUT_FOSSA_BRANCH}" ]            && export FOSSA_BRANCH="${INPUT_FOSSA_BRANCH}"
-        [ -n "${INPUT_FOSSA_REVISION}" ]          && export FOSSA_REVISION="${INPUT_FOSSA_REVISION}"
-        [ -n "${INPUT_FOSSA_REVISION_SCAN_ID}" ]  && export FOSSA_REVISION_SCAN_ID="${INPUT_FOSSA_REVISION_SCAN_ID}"
-        [ -n "${INPUT_FOSSA_RELEASE}" ]           && export FOSSA_RELEASE="${INPUT_FOSSA_RELEASE}"
-        [ -n "${INPUT_FOSSA_RELEASE_SCAN_ID}" ]   && export FOSSA_RELEASE_SCAN_ID="${INPUT_FOSSA_RELEASE_SCAN_ID}"
-        [ -n "${INPUT_SLACK_TOKEN}" ]             && export SLACK_TOKEN="${INPUT_SLACK_TOKEN}"
-        [ -n "${INPUT_SLACK_CHANNEL}" ]           && export SLACK_CHANNEL="${INPUT_SLACK_CHANNEL}"
-        [ -n "${INPUT_SLACK_THREAD_TS}" ]         && export SLACK_THREAD_TS="${INPUT_SLACK_THREAD_TS}"
-        [ -n "${INPUT_GITHUB_REPOSITORY}" ]       && export GITHUB_REPOSITORY="${INPUT_GITHUB_REPOSITORY}"
-        [ -n "${INPUT_GITHUB_RUN_ID}" ]           && export GITHUB_RUN_ID="${INPUT_GITHUB_RUN_ID}"
-        [ -n "${INPUT_GITHUB_SERVER_URL}" ]       && export GITHUB_SERVER_URL="${INPUT_GITHUB_SERVER_URL}"
-        [ -n "${INPUT_GITHUB_TOKEN}" ]            && export GITHUB_TOKEN="${INPUT_GITHUB_TOKEN}"
-        [ -n "${INPUT_ENABLE_PR_COMMENT}" ]       && export ENABLE_PR_COMMENT="${INPUT_ENABLE_PR_COMMENT}"
-        [ -n "${INPUT_ENABLE_STATUS_CHECK}" ]     && export ENABLE_STATUS_CHECK="${INPUT_ENABLE_STATUS_CHECK}"
-        [ -n "${INPUT_STATUS_CHECK_NAME}" ]       && export STATUS_CHECK_NAME="${INPUT_STATUS_CHECK_NAME}"
-        [ -n "${INPUT_PR_COMMENT_MAX_VIOLATIONS}" ] && export PR_COMMENT_MAX_VIOLATIONS="${INPUT_PR_COMMENT_MAX_VIOLATIONS}"
-        [ -n "${INPUT_ENABLE_DIFF_MODE}" ]        && export ENABLE_DIFF_MODE="${INPUT_ENABLE_DIFF_MODE}"
-        [ -n "${INPUT_DIFF_BASE_REVISION_SHA}" ]  && export DIFF_BASE_REVISION_SHA="${INPUT_DIFF_BASE_REVISION_SHA}"
-        [ -n "${INPUT_ENABLE_LICENSE_ENRICHMENT}" ] && export ENABLE_LICENSE_ENRICHMENT="${INPUT_ENABLE_LICENSE_ENRICHMENT}"
-        [ -n "${INPUT_ENABLE_PRIVACY_MODE}" ]     && export ENABLE_PRIVACY_MODE="${INPUT_ENABLE_PRIVACY_MODE}"
+        # Use ${{ inputs.xxx }} syntax (evaluated by GitHub before bash runs) to
+        # reliably populate env vars from action inputs. This is required for
+        # composite actions — INPUT_* env vars are not always available in
+        # composite action shell steps. Secrets are masked as *** in logs.
+        # Values are then passed to docker via -e KEY (by reference), so they
+        # are never visible as command-line argument values in the process list.
+        export FOSSA_API_KEY="${{ inputs.fossa_api_key }}"
+        export FOSSA_PROJECT_ID="${{ inputs.fossa_project_id }}"
+        export FOSSA_CATEGORY="${{ inputs.fossa_category }}"
+        [ -n "${{ inputs.fossa_mode }}" ]               && export FOSSA_MODE="${{ inputs.fossa_mode }}"
+        [ -n "${{ inputs.block_on }}" ]                 && export BLOCK_ON="${{ inputs.block_on }}"
+        [ -n "${{ inputs.fossa_branch }}" ]             && export FOSSA_BRANCH="${{ inputs.fossa_branch }}"
+        [ -n "${{ inputs.fossa_revision }}" ]           && export FOSSA_REVISION="${{ inputs.fossa_revision }}"
+        [ -n "${{ inputs.fossa_revision_scan_id }}" ]   && export FOSSA_REVISION_SCAN_ID="${{ inputs.fossa_revision_scan_id }}"
+        [ -n "${{ inputs.fossa_release }}" ]            && export FOSSA_RELEASE="${{ inputs.fossa_release }}"
+        [ -n "${{ inputs.fossa_release_scan_id }}" ]    && export FOSSA_RELEASE_SCAN_ID="${{ inputs.fossa_release_scan_id }}"
+        [ -n "${{ inputs.slack_token }}" ]              && export SLACK_TOKEN="${{ inputs.slack_token }}"
+        [ -n "${{ inputs.slack_channel }}" ]            && export SLACK_CHANNEL="${{ inputs.slack_channel }}"
+        [ -n "${{ inputs.slack_thread_ts }}" ]          && export SLACK_THREAD_TS="${{ inputs.slack_thread_ts }}"
+        [ -n "${{ inputs.github_repository }}" ]        && export GITHUB_REPOSITORY="${{ inputs.github_repository }}"
+        [ -n "${{ inputs.github_run_id }}" ]            && export GITHUB_RUN_ID="${{ inputs.github_run_id }}"
+        [ -n "${{ inputs.github_server_url }}" ]        && export GITHUB_SERVER_URL="${{ inputs.github_server_url }}"
+        [ -n "${{ inputs.github_token }}" ]             && export GITHUB_TOKEN="${{ inputs.github_token }}"
+        [ -n "${{ inputs.enable_pr_comment }}" ]        && export ENABLE_PR_COMMENT="${{ inputs.enable_pr_comment }}"
+        [ -n "${{ inputs.enable_status_check }}" ]      && export ENABLE_STATUS_CHECK="${{ inputs.enable_status_check }}"
+        [ -n "${{ inputs.status_check_name }}" ]        && export STATUS_CHECK_NAME="${{ inputs.status_check_name }}"
+        [ -n "${{ inputs.pr_comment_max_violations }}" ] && export PR_COMMENT_MAX_VIOLATIONS="${{ inputs.pr_comment_max_violations }}"
+        [ -n "${{ inputs.enable_diff_mode }}" ]         && export ENABLE_DIFF_MODE="${{ inputs.enable_diff_mode }}"
+        [ -n "${{ inputs.diff_base_revision_sha }}" ]   && export DIFF_BASE_REVISION_SHA="${{ inputs.diff_base_revision_sha }}"
+        [ -n "${{ inputs.enable_license_enrichment }}" ] && export ENABLE_LICENSE_ENRICHMENT="${{ inputs.enable_license_enrichment }}"
+        [ -n "${{ inputs.enable_privacy_mode }}" ]      && export ENABLE_PRIVACY_MODE="${{ inputs.enable_privacy_mode }}"
 
         docker run --rm \
           -e FOSSA_API_KEY \

--- a/.github/actions/fossa-guard/action.yaml
+++ b/.github/actions/fossa-guard/action.yaml
@@ -122,9 +122,9 @@ runs:
         [ -n "${{ inputs.github_run_id }}" ]            && export GITHUB_RUN_ID="${{ inputs.github_run_id }}"
         [ -n "${{ inputs.github_server_url }}" ]        && export GITHUB_SERVER_URL="${{ inputs.github_server_url }}"
         # GITHUB_TOKEN is inherited from the runner environment via -e GITHUB_TOKEN
-        # in the docker run below — no explicit export needed, and skipping the
-        # inline ${{ inputs.github_token }} substitution prevents the token value
-        # from being registered for masking (which would over-mask branch/project values).
+        # in the docker run below — no explicit export needed. Avoiding any
+        # inline expression substitution for the token prevents its value from
+        # being registered for masking (which would over-mask branch/project values).
         [ -n "${{ inputs.enable_pr_comment }}" ]        && export ENABLE_PR_COMMENT="${{ inputs.enable_pr_comment }}"
         [ -n "${{ inputs.enable_status_check }}" ]      && export ENABLE_STATUS_CHECK="${{ inputs.enable_status_check }}"
         [ -n "${{ inputs.status_check_name }}" ]        && export STATUS_CHECK_NAME="${{ inputs.status_check_name }}"

--- a/.github/actions/fossa-guard/action.yaml
+++ b/.github/actions/fossa-guard/action.yaml
@@ -93,6 +93,11 @@ runs:
       run: |
         OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
 
+        # Authenticate to GHCR using the calling workflow's token so internal
+        # org packages can be pulled. runs.using: docker did this automatically;
+        # with composite + docker run we handle it explicitly.
+        echo "${{ github.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
         # Map INPUT_* vars to the names the container scripts expect, then pass
         # each to docker via -e KEY (by reference from the current process env).
         # This is the safer approach: secrets are never written to disk and never

--- a/.github/actions/fossa-guard/action.yaml
+++ b/.github/actions/fossa-guard/action.yaml
@@ -171,5 +171,5 @@ runs:
           -v "${GITHUB_WORKSPACE}:/github/workspace" \
           -v "${RUNNER_TEMP}:${RUNNER_TEMP}" \
           --workdir /github/workspace \
-          "ghcr.io/${OWNER}/maas-build-actions:latest" \
+          "ghcr.io/${OWNER}/maas-build-actions@sha256:6182de169f2016eeab994aed8626edb1295d43720cd4485d43301d8e6b5c35fc" \
           /bin/sh -c 'source /maas-build-actions/venv/bin/activate && python3 /maas-build-actions/scripts/fossa-guard/fossa_guard.py'

--- a/.github/actions/fossa-guard/action.yaml
+++ b/.github/actions/fossa-guard/action.yaml
@@ -98,14 +98,14 @@ runs:
         # with composite + docker run we handle it explicitly.
         echo "${{ github.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
-        # FOSSA_API_KEY uses INPUT_* (set by GitHub Actions for all action inputs)
-        # rather than inline ${{ inputs.fossa_api_key }} substitution. Inline
-        # substitution registers the secret for masking, and if the API key
-        # contains common substrings (e.g. "main"), GitHub will over-mask
-        # unrelated non-secret values like branch names and project IDs.
-        # All other inputs use ${{ inputs.xxx }} which is the reliable way to
-        # read non-secret values in composite action shell steps.
-        export FOSSA_API_KEY="${INPUT_FOSSA_API_KEY}"
+        # Use ${{ inputs.xxx }} syntax for all inputs. INPUT_* env vars are not
+        # reliably set in composite action shell steps, so inline substitution
+        # is the only way to ensure values are passed.
+        # GITHUB_TOKEN is NOT exported here — it is already present in the
+        # runner environment (set automatically by GitHub Actions) and is
+        # inherited by the container via -e GITHUB_TOKEN without any inline
+        # substitution, preventing its value from over-masking other outputs.
+        export FOSSA_API_KEY="${{ inputs.fossa_api_key }}"
         export FOSSA_PROJECT_ID="${{ inputs.fossa_project_id }}"
         export FOSSA_CATEGORY="${{ inputs.fossa_category }}"
         [ -n "${{ inputs.fossa_mode }}" ]               && export FOSSA_MODE="${{ inputs.fossa_mode }}"
@@ -121,7 +121,10 @@ runs:
         [ -n "${{ inputs.github_repository }}" ]        && export GITHUB_REPOSITORY="${{ inputs.github_repository }}"
         [ -n "${{ inputs.github_run_id }}" ]            && export GITHUB_RUN_ID="${{ inputs.github_run_id }}"
         [ -n "${{ inputs.github_server_url }}" ]        && export GITHUB_SERVER_URL="${{ inputs.github_server_url }}"
-        [ -n "${{ inputs.github_token }}" ]             && export GITHUB_TOKEN="${{ inputs.github_token }}"
+        # GITHUB_TOKEN is inherited from the runner environment via -e GITHUB_TOKEN
+        # in the docker run below — no explicit export needed, and skipping the
+        # inline ${{ inputs.github_token }} substitution prevents the token value
+        # from being registered for masking (which would over-mask branch/project values).
         [ -n "${{ inputs.enable_pr_comment }}" ]        && export ENABLE_PR_COMMENT="${{ inputs.enable_pr_comment }}"
         [ -n "${{ inputs.enable_status_check }}" ]      && export ENABLE_STATUS_CHECK="${{ inputs.enable_status_check }}"
         [ -n "${{ inputs.status_check_name }}" ]        && export STATUS_CHECK_NAME="${{ inputs.status_check_name }}"

--- a/.github/actions/fossa-guard/action.yaml
+++ b/.github/actions/fossa-guard/action.yaml
@@ -98,13 +98,14 @@ runs:
         # with composite + docker run we handle it explicitly.
         echo "${{ github.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
-        # Use ${{ inputs.xxx }} syntax (evaluated by GitHub before bash runs) to
-        # reliably populate env vars from action inputs. This is required for
-        # composite actions — INPUT_* env vars are not always available in
-        # composite action shell steps. Secrets are masked as *** in logs.
-        # Values are then passed to docker via -e KEY (by reference), so they
-        # are never visible as command-line argument values in the process list.
-        export FOSSA_API_KEY="${{ inputs.fossa_api_key }}"
+        # FOSSA_API_KEY uses INPUT_* (set by GitHub Actions for all action inputs)
+        # rather than inline ${{ inputs.fossa_api_key }} substitution. Inline
+        # substitution registers the secret for masking, and if the API key
+        # contains common substrings (e.g. "main"), GitHub will over-mask
+        # unrelated non-secret values like branch names and project IDs.
+        # All other inputs use ${{ inputs.xxx }} which is the reliable way to
+        # read non-secret values in composite action shell steps.
+        export FOSSA_API_KEY="${INPUT_FOSSA_API_KEY}"
         export FOSSA_PROJECT_ID="${{ inputs.fossa_project_id }}"
         export FOSSA_CATEGORY="${{ inputs.fossa_category }}"
         [ -n "${{ inputs.fossa_mode }}" ]               && export FOSSA_MODE="${{ inputs.fossa_mode }}"

--- a/.github/actions/fossa-guard/action.yaml
+++ b/.github/actions/fossa-guard/action.yaml
@@ -87,7 +87,7 @@ inputs:
 
 runs:
   using: docker
-  image: docker://ghcr.io/solacedev/maas-build-actions:latest
+  image: docker://ghcr.io/${{ github.repository_owner }}/maas-build-actions:latest
   entrypoint: /bin/sh
   args:
     - -c

--- a/.github/actions/generate-fossa-report/action.yaml
+++ b/.github/actions/generate-fossa-report/action.yaml
@@ -48,6 +48,11 @@ runs:
       run: |
         OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
 
+        # Authenticate to GHCR using the calling workflow's token so internal
+        # org packages can be pulled. runs.using: docker did this automatically;
+        # with composite + docker run we handle it explicitly.
+        echo "${{ github.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
         # Map INPUT_* vars to the names the container scripts expect, then pass
         # each to docker via -e KEY (by reference from the current process env).
         # This is the safer approach: secrets are never written to disk and never

--- a/.github/actions/generate-fossa-report/action.yaml
+++ b/.github/actions/generate-fossa-report/action.yaml
@@ -86,5 +86,5 @@ runs:
           -v "${GITHUB_WORKSPACE}:/github/workspace" \
           -v "${RUNNER_TEMP}:${RUNNER_TEMP}" \
           --workdir /github/workspace \
-          "ghcr.io/${OWNER}/maas-build-actions:latest" \
+          "ghcr.io/${OWNER}/maas-build-actions@sha256:6182de169f2016eeab994aed8626edb1295d43720cd4485d43301d8e6b5c35fc" \
           /bin/sh -c 'bash /maas-build-actions/actions/generate-fossa-report/generate-report.sh'

--- a/.github/actions/generate-fossa-report/action.yaml
+++ b/.github/actions/generate-fossa-report/action.yaml
@@ -41,34 +41,45 @@ inputs:
     required: false
 
 runs:
-  using: docker
-  image: docker://ghcr.io/${{ github.repository_owner }}/maas-build-actions:latest
-  entrypoint: /bin/sh
-  args:
-    - -c
-    - |
-      export FOSSA_API_KEY="$INPUT_FOSSA_API_KEY"
-      export ORG_ID="$INPUT_ORG_ID"
-      if [ -n "$INPUT_PROJECT_LOCATOR" ]; then export PROJECT_LOCATOR="$INPUT_PROJECT_LOCATOR"; fi
-      export FOSSA_CONFIG_FILE="$INPUT_FOSSA_CONFIG_FILE"
-      if [ -n "$INPUT_REVISION_ID" ]; then export REVISION_ID="$INPUT_REVISION_ID"; fi
-      if [ -n "$INPUT_RELEASE_GROUP_ID" ]; then export RELEASE_GROUP_ID="$INPUT_RELEASE_GROUP_ID"; fi
-      if [ -n "$INPUT_RELEASE_ID" ]; then export RELEASE_ID="$INPUT_RELEASE_ID"; fi
-      export FORMAT="$INPUT_FORMAT"
-      export OUTPUT_FILE="$INPUT_OUTPUT_FILE"
-      export REPORT_PROFILE="$INPUT_REPORT_PROFILE"
-      if [ -n "$INPUT_REPORT_PARAMETERS" ]; then export REPORT_PARAMETERS="$INPUT_REPORT_PARAMETERS"; fi
+  using: composite
+  steps:
+    - name: Generate FOSSA Report
+      shell: bash
+      run: |
+        OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
 
-      echo "Generating FOSSA report..."
-      if [ -n "$RELEASE_GROUP_ID" ]; then
-        echo "Release Group ID: $RELEASE_GROUP_ID"
-        echo "Release ID: $RELEASE_ID"
-      else
-        echo "Project: $ORG_ID/$PROJECT_LOCATOR"
-        echo "Revision: $REVISION_ID"
-      fi
-      echo "Format: $FORMAT"
-      echo "Profile: $REPORT_PROFILE"
-      echo "Output: $OUTPUT_FILE"
+        # Map INPUT_* vars to the names the container scripts expect, then pass
+        # each to docker via -e KEY (by reference from the current process env).
+        # This is the safer approach: secrets are never written to disk and never
+        # appear as command-line argument values visible in the process list.
+        export FOSSA_API_KEY="${INPUT_FOSSA_API_KEY}"
+        export ORG_ID="${INPUT_ORG_ID}"
+        export FOSSA_CONFIG_FILE="${INPUT_FOSSA_CONFIG_FILE}"
+        export FORMAT="${INPUT_FORMAT}"
+        export OUTPUT_FILE="${INPUT_OUTPUT_FILE}"
+        export REPORT_PROFILE="${INPUT_REPORT_PROFILE}"
+        [ -n "${INPUT_PROJECT_LOCATOR}" ]    && export PROJECT_LOCATOR="${INPUT_PROJECT_LOCATOR}"
+        [ -n "${INPUT_REVISION_ID}" ]        && export REVISION_ID="${INPUT_REVISION_ID}"
+        [ -n "${INPUT_RELEASE_GROUP_ID}" ]   && export RELEASE_GROUP_ID="${INPUT_RELEASE_GROUP_ID}"
+        [ -n "${INPUT_RELEASE_ID}" ]         && export RELEASE_ID="${INPUT_RELEASE_ID}"
+        [ -n "${INPUT_REPORT_PARAMETERS}" ]  && export REPORT_PARAMETERS="${INPUT_REPORT_PARAMETERS}"
 
-      bash /maas-build-actions/actions/generate-fossa-report/generate-report.sh
+        docker run --rm \
+          -e FOSSA_API_KEY \
+          -e ORG_ID \
+          -e FOSSA_CONFIG_FILE \
+          -e FORMAT \
+          -e OUTPUT_FILE \
+          -e REPORT_PROFILE \
+          -e PROJECT_LOCATOR \
+          -e REVISION_ID \
+          -e RELEASE_GROUP_ID \
+          -e RELEASE_ID \
+          -e REPORT_PARAMETERS \
+          -e GITHUB_OUTPUT \
+          -e GITHUB_STEP_SUMMARY \
+          -v "${GITHUB_WORKSPACE}:/github/workspace" \
+          -v "${RUNNER_TEMP}:${RUNNER_TEMP}" \
+          --workdir /github/workspace \
+          "ghcr.io/${OWNER}/maas-build-actions:latest" \
+          /bin/sh -c 'bash /maas-build-actions/actions/generate-fossa-report/generate-report.sh'

--- a/.github/actions/generate-fossa-report/action.yaml
+++ b/.github/actions/generate-fossa-report/action.yaml
@@ -42,7 +42,7 @@ inputs:
 
 runs:
   using: docker
-  image: docker://ghcr.io/solacedev/maas-build-actions:latest
+  image: docker://ghcr.io/${{ github.repository_owner }}/maas-build-actions:latest
   entrypoint: /bin/sh
   args:
     - -c

--- a/.github/workflows/hatch_release_pypi.yml
+++ b/.github/workflows/hatch_release_pypi.yml
@@ -105,6 +105,7 @@ permissions:
   contents: write
   checks: write
   pull-requests: read
+  packages: write
 
 jobs:
   release:

--- a/.github/workflows/hatch_release_pypi.yml
+++ b/.github/workflows/hatch_release_pypi.yml
@@ -140,6 +140,7 @@ jobs:
           GH_REPO: ${{ github.event.repository.name }}
           GITHUB_SHA: ${{ github.sha }}
         run: |
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
           docker run --rm \
             -e AWS_ACCESS_KEY_ID \
             -e AWS_SECRET_ACCESS_KEY \
@@ -155,7 +156,7 @@ jobs:
             -e GH_ORG \
             -e GH_REPO \
             -e GITHUB_SHA \
-            ghcr.io/${{ github.repository_owner }}/maas-build-actions:latest \
+            ghcr.io/${OWNER}/maas-build-actions:latest \
             /bin/sh -c '. $VIRTUAL_ENV/bin/activate && cd $ACTIONS_PATH/prisma-vulnerability-checker && python prisma_vulnerability_checker.py'
       - name: Run SonarQube Hotspot Check
         if: ${{ fromJson(inputs.sonarqube_hotspot_check) }}
@@ -165,12 +166,13 @@ jobs:
           SONARQUBE_QUERY_TOKEN: ${{ secrets.SONARQUBE_QUERY_TOKEN }}
           SONARQUBE_HOTSPOTS_API_URL: ${{ secrets.SONARQUBE_HOTSPOTS_API_URL }}
         run: |
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
           docker run --rm \
             -e SONARQUBE_PROJECT_KEY \
             -e SONARQUBE_PROJECT_MAIN_BRANCH \
             -e SONARQUBE_QUERY_TOKEN \
             -e SONARQUBE_HOTSPOTS_API_URL \
-            ghcr.io/${{ github.repository_owner }}/maas-build-actions:latest \
+            ghcr.io/${OWNER}/maas-build-actions:latest \
             /bin/sh -c '. $VIRTUAL_ENV/bin/activate && cd $ACTIONS_PATH/sonarqube-hotspot-checker && python sonarqube_checker.py'
 
       - name: Setup Node.js

--- a/.github/workflows/hatch_release_pypi.yml
+++ b/.github/workflows/hatch_release_pypi.yml
@@ -124,7 +124,6 @@ jobs:
 
       - name: Run Prisma Check
         if: ${{ fromJson(inputs.prisma_check) }}
-        uses: docker://ghcr.io/solacedev/maas-build-actions:latest
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.MANIFEST_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.MANIFEST_AWS_SECRET_ACCESS_KEY }}
@@ -140,28 +139,39 @@ jobs:
           GH_ORG: ${{ github.repository_owner }}
           GH_REPO: ${{ github.event.repository.name }}
           GITHUB_SHA: ${{ github.sha }}
-        with:
-          entrypoint: /bin/sh
-          args: >
-            -c ". $VIRTUAL_ENV/bin/activate &&
-            cd $ACTIONS_PATH/prisma-vulnerability-checker &&
-            python prisma_vulnerability_checker.py
-            "
+        run: |
+          docker run --rm \
+            -e AWS_ACCESS_KEY_ID \
+            -e AWS_SECRET_ACCESS_KEY \
+            -e PRISMA_REPOSITORY_NAME \
+            -e DOCKER_IMAGE_TO_CHECK \
+            -e PRISMA_ACCESS_KEY_ID \
+            -e PRISMA_ACCESS_KEY_SECRET \
+            -e PRISMA_JIRA_CHECK \
+            -e AWS_REGION \
+            -e JIRA_ONLY \
+            -e STATUS_CHECK \
+            -e GH_TOKEN \
+            -e GH_ORG \
+            -e GH_REPO \
+            -e GITHUB_SHA \
+            ghcr.io/${{ github.repository_owner }}/maas-build-actions:latest \
+            /bin/sh -c '. $VIRTUAL_ENV/bin/activate && cd $ACTIONS_PATH/prisma-vulnerability-checker && python prisma_vulnerability_checker.py'
       - name: Run SonarQube Hotspot Check
-        uses: docker://ghcr.io/solacedev/maas-build-actions:latest
         if: ${{ fromJson(inputs.sonarqube_hotspot_check) }}
         env:
           SONARQUBE_PROJECT_KEY: ${{ secrets.SONARQUBE_PROJECT_KEY }}
           SONARQUBE_PROJECT_MAIN_BRANCH: ${{ secrets.SONARQUBE_PROJECT_MAIN_BRANCH }}
           SONARQUBE_QUERY_TOKEN: ${{ secrets.SONARQUBE_QUERY_TOKEN }}
           SONARQUBE_HOTSPOTS_API_URL: ${{ secrets.SONARQUBE_HOTSPOTS_API_URL }}
-        with:
-          entrypoint: /bin/sh
-          args: >
-            -c ". $VIRTUAL_ENV/bin/activate &&
-            cd $ACTIONS_PATH/sonarqube-hotspot-checker &&
-            python sonarqube_checker.py
-            "
+        run: |
+          docker run --rm \
+            -e SONARQUBE_PROJECT_KEY \
+            -e SONARQUBE_PROJECT_MAIN_BRANCH \
+            -e SONARQUBE_QUERY_TOKEN \
+            -e SONARQUBE_HOTSPOTS_API_URL \
+            ghcr.io/${{ github.repository_owner }}/maas-build-actions:latest \
+            /bin/sh -c '. $VIRTUAL_ENV/bin/activate && cd $ACTIONS_PATH/sonarqube-hotspot-checker && python sonarqube_checker.py'
 
       - name: Setup Node.js
         if: inputs.npm_package_path != ''

--- a/.github/workflows/hatch_release_pypi.yml
+++ b/.github/workflows/hatch_release_pypi.yml
@@ -158,7 +158,7 @@ jobs:
             -e GH_ORG \
             -e GH_REPO \
             -e GITHUB_SHA \
-            ghcr.io/${OWNER}/maas-build-actions:latest \
+            ghcr.io/${OWNER}/maas-build-actions@sha256:6182de169f2016eeab994aed8626edb1295d43720cd4485d43301d8e6b5c35fc \
             /bin/sh -c '. $VIRTUAL_ENV/bin/activate && cd $ACTIONS_PATH/prisma-vulnerability-checker && python prisma_vulnerability_checker.py'
       - name: Run SonarQube Hotspot Check
         if: ${{ fromJson(inputs.sonarqube_hotspot_check) }}
@@ -175,7 +175,7 @@ jobs:
             -e SONARQUBE_PROJECT_MAIN_BRANCH \
             -e SONARQUBE_QUERY_TOKEN \
             -e SONARQUBE_HOTSPOTS_API_URL \
-            ghcr.io/${OWNER}/maas-build-actions:latest \
+            ghcr.io/${OWNER}/maas-build-actions@sha256:6182de169f2016eeab994aed8626edb1295d43720cd4485d43301d8e6b5c35fc \
             /bin/sh -c '. $VIRTUAL_ENV/bin/activate && cd $ACTIONS_PATH/sonarqube-hotspot-checker && python sonarqube_checker.py'
 
       - name: Setup Node.js

--- a/.github/workflows/hatch_release_pypi.yml
+++ b/.github/workflows/hatch_release_pypi.yml
@@ -141,6 +141,7 @@ jobs:
           GITHUB_SHA: ${{ github.sha }}
         run: |
           OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          echo "${{ github.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
           docker run --rm \
             -e AWS_ACCESS_KEY_ID \
             -e AWS_SECRET_ACCESS_KEY \
@@ -167,6 +168,7 @@ jobs:
           SONARQUBE_HOTSPOTS_API_URL: ${{ secrets.SONARQUBE_HOTSPOTS_API_URL }}
         run: |
           OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          echo "${{ github.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
           docker run --rm \
             -e SONARQUBE_PROJECT_KEY \
             -e SONARQUBE_PROJECT_MAIN_BRANCH \

--- a/.github/workflows/hatch_release_pypi.yml
+++ b/.github/workflows/hatch_release_pypi.yml
@@ -105,7 +105,7 @@ permissions:
   contents: write
   checks: write
   pull-requests: read
-  packages: write
+  packages: read
 
 jobs:
   release:

--- a/.github/workflows/hatch_release_security_checks.yml
+++ b/.github/workflows/hatch_release_security_checks.yml
@@ -73,7 +73,6 @@ jobs:
       - name: FOSSA Guard - Block on Policy Violations
         uses: SolaceDev/solace-public-workflows/.github/actions/fossa-guard@feat/dynamic-github-org-image-pull
         # if: github.ref_name == github.event.repository.default_branch && fromJson(inputs.fossa_check)
-        if: fromJson(inputs.fossa_check)
         continue-on-error: true
         with:
           fossa_api_key: ${{ secrets.FOSSA_API_KEY }}
@@ -87,7 +86,6 @@ jobs:
       - name: FOSSA Guard - Block on Security Vulnerabilities
         uses: SolaceDev/solace-public-workflows/.github/actions/fossa-guard@feat/dynamic-github-org-image-pull
         # if: github.ref_name == github.event.repository.default_branch && fromJson(inputs.fossa_check)
-        if: fromJson(inputs.fossa_check)
         continue-on-error: true
         with:
           fossa_api_key: ${{ secrets.FOSSA_API_KEY }}

--- a/.github/workflows/hatch_release_security_checks.yml
+++ b/.github/workflows/hatch_release_security_checks.yml
@@ -114,6 +114,7 @@ jobs:
           GITHUB_SHA: ${{ github.sha }}
         run: |
           OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          echo "${{ github.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
           docker run --rm \
             -e AWS_ACCESS_KEY_ID \
             -e AWS_SECRET_ACCESS_KEY \
@@ -141,6 +142,7 @@ jobs:
           SONARQUBE_HOTSPOTS_API_URL: ${{ secrets.SONARQUBE_HOTSPOTS_API_URL }}
         run: |
           OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          echo "${{ github.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
           docker run --rm \
             -e SONARQUBE_PROJECT_KEY \
             -e SONARQUBE_PROJECT_MAIN_BRANCH \

--- a/.github/workflows/hatch_release_security_checks.yml
+++ b/.github/workflows/hatch_release_security_checks.yml
@@ -71,7 +71,7 @@ jobs:
           fetch-depth: 0
 
       - name: FOSSA Guard - Block on Policy Violations
-        uses: SolaceDev/solace-public-workflows/.github/actions/fossa-guard@feat/dynamic-github-org-image-pull
+        uses: SolaceDev/solace-public-workflows/.github/actions/fossa-guard@main
         # if: github.ref_name == github.event.repository.default_branch && fromJson(inputs.fossa_check)
         continue-on-error: true
         with:
@@ -84,7 +84,7 @@ jobs:
           block_on: policy_conflict
 
       - name: FOSSA Guard - Block on Security Vulnerabilities
-        uses: SolaceDev/solace-public-workflows/.github/actions/fossa-guard@feat/dynamic-github-org-image-pull
+        uses: SolaceDev/solace-public-workflows/.github/actions/fossa-guard@main
         # if: github.ref_name == github.event.repository.default_branch && fromJson(inputs.fossa_check)
         continue-on-error: true
         with:

--- a/.github/workflows/hatch_release_security_checks.yml
+++ b/.github/workflows/hatch_release_security_checks.yml
@@ -70,8 +70,9 @@ jobs:
           fetch-depth: 0
 
       - name: FOSSA Guard - Block on Policy Violations
-        uses: SolaceDev/solace-public-workflows/.github/actions/fossa-guard@main
-        if: github.ref_name == github.event.repository.default_branch && fromJson(inputs.fossa_check)
+        uses: SolaceDev/solace-public-workflows/.github/actions/fossa-guard@feat/dynamic-github-org-image-pull
+        # if: github.ref_name == github.event.repository.default_branch && fromJson(inputs.fossa_check)
+        if: fromJson(inputs.fossa_check)
         continue-on-error: true
         with:
           fossa_api_key: ${{ secrets.FOSSA_API_KEY }}
@@ -83,8 +84,9 @@ jobs:
           block_on: policy_conflict
 
       - name: FOSSA Guard - Block on Security Vulnerabilities
-        uses: SolaceDev/solace-public-workflows/.github/actions/fossa-guard@main
-        if: github.ref_name == github.event.repository.default_branch && fromJson(inputs.fossa_check)
+        uses: SolaceDev/solace-public-workflows/.github/actions/fossa-guard@feat/dynamic-github-org-image-pull
+        # if: github.ref_name == github.event.repository.default_branch && fromJson(inputs.fossa_check)
+        if: fromJson(inputs.fossa_check)
         continue-on-error: true
         with:
           fossa_api_key: ${{ secrets.FOSSA_API_KEY }}

--- a/.github/workflows/hatch_release_security_checks.yml
+++ b/.github/workflows/hatch_release_security_checks.yml
@@ -71,7 +71,7 @@ jobs:
           fetch-depth: 0
 
       - name: FOSSA Guard - Block on Policy Violations
-        uses: SolaceDev/solace-public-workflows/.github/actions/fossa-guard@main
+        uses: SolaceDev/solace-public-workflows/.github/actions/fossa-guard@feat/dynamic-github-org-image-pull
         # if: github.ref_name == github.event.repository.default_branch && fromJson(inputs.fossa_check)
         continue-on-error: true
         with:
@@ -84,7 +84,7 @@ jobs:
           block_on: policy_conflict
 
       - name: FOSSA Guard - Block on Security Vulnerabilities
-        uses: SolaceDev/solace-public-workflows/.github/actions/fossa-guard@main
+        uses: SolaceDev/solace-public-workflows/.github/actions/fossa-guard@feat/dynamic-github-org-image-pull
         # if: github.ref_name == github.event.repository.default_branch && fromJson(inputs.fossa_check)
         continue-on-error: true
         with:

--- a/.github/workflows/hatch_release_security_checks.yml
+++ b/.github/workflows/hatch_release_security_checks.yml
@@ -97,7 +97,6 @@ jobs:
 
       - name: Run Prisma Check
         if: ${{ fromJson(inputs.prisma_check) }}
-        uses: docker://ghcr.io/solacedev/maas-build-actions:latest
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.MANIFEST_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.MANIFEST_AWS_SECRET_ACCESS_KEY }}
@@ -113,26 +112,37 @@ jobs:
           GH_ORG: ${{ github.repository_owner }}
           GH_REPO: ${{ github.event.repository.name }}
           GITHUB_SHA: ${{ github.sha }}
-        with:
-          entrypoint: /bin/sh
-          args: >
-            -c ". $VIRTUAL_ENV/bin/activate &&
-            cd $ACTIONS_PATH/prisma-vulnerability-checker &&
-            python prisma_vulnerability_checker.py
-            "
+        run: |
+          docker run --rm \
+            -e AWS_ACCESS_KEY_ID \
+            -e AWS_SECRET_ACCESS_KEY \
+            -e PRISMA_REPOSITORY_NAME \
+            -e DOCKER_IMAGE_TO_CHECK \
+            -e PRISMA_ACCESS_KEY_ID \
+            -e PRISMA_ACCESS_KEY_SECRET \
+            -e PRISMA_JIRA_CHECK \
+            -e AWS_REGION \
+            -e JIRA_ONLY \
+            -e STATUS_CHECK \
+            -e GH_TOKEN \
+            -e GH_ORG \
+            -e GH_REPO \
+            -e GITHUB_SHA \
+            ghcr.io/${{ github.repository_owner }}/maas-build-actions:latest \
+            /bin/sh -c '. $VIRTUAL_ENV/bin/activate && cd $ACTIONS_PATH/prisma-vulnerability-checker && python prisma_vulnerability_checker.py'
 
       - name: Run SonarQube Hotspot Check
-        uses: docker://ghcr.io/solacedev/maas-build-actions:latest
         if: ${{ fromJson(inputs.sonarqube_hotspot_check) }}
         env:
           SONARQUBE_PROJECT_KEY: ${{ secrets.SONARQUBE_PROJECT_KEY }}
           SONARQUBE_PROJECT_MAIN_BRANCH: ${{ secrets.SONARQUBE_PROJECT_MAIN_BRANCH }}
           SONARQUBE_QUERY_TOKEN: ${{ secrets.SONARQUBE_QUERY_TOKEN }}
           SONARQUBE_HOTSPOTS_API_URL: ${{ secrets.SONARQUBE_HOTSPOTS_API_URL }}
-        with:
-          entrypoint: /bin/sh
-          args: >
-            -c ". $VIRTUAL_ENV/bin/activate &&
-            cd $ACTIONS_PATH/sonarqube-hotspot-checker &&
-            python sonarqube_checker.py
-            "
+        run: |
+          docker run --rm \
+            -e SONARQUBE_PROJECT_KEY \
+            -e SONARQUBE_PROJECT_MAIN_BRANCH \
+            -e SONARQUBE_QUERY_TOKEN \
+            -e SONARQUBE_HOTSPOTS_API_URL \
+            ghcr.io/${{ github.repository_owner }}/maas-build-actions:latest \
+            /bin/sh -c '. $VIRTUAL_ENV/bin/activate && cd $ACTIONS_PATH/sonarqube-hotspot-checker && python sonarqube_checker.py'

--- a/.github/workflows/hatch_release_security_checks.yml
+++ b/.github/workflows/hatch_release_security_checks.yml
@@ -57,6 +57,7 @@ permissions:
   contents: read
   checks: write
   pull-requests: read
+  packages: read
 
 jobs:
   security-checks:

--- a/.github/workflows/hatch_release_security_checks.yml
+++ b/.github/workflows/hatch_release_security_checks.yml
@@ -131,7 +131,7 @@ jobs:
             -e GH_ORG \
             -e GH_REPO \
             -e GITHUB_SHA \
-            ghcr.io/${OWNER}/maas-build-actions:latest \
+            ghcr.io/${OWNER}/maas-build-actions@sha256:6182de169f2016eeab994aed8626edb1295d43720cd4485d43301d8e6b5c35fc \
             /bin/sh -c '. $VIRTUAL_ENV/bin/activate && cd $ACTIONS_PATH/prisma-vulnerability-checker && python prisma_vulnerability_checker.py'
 
       - name: Run SonarQube Hotspot Check
@@ -149,5 +149,5 @@ jobs:
             -e SONARQUBE_PROJECT_MAIN_BRANCH \
             -e SONARQUBE_QUERY_TOKEN \
             -e SONARQUBE_HOTSPOTS_API_URL \
-            ghcr.io/${OWNER}/maas-build-actions:latest \
+            ghcr.io/${OWNER}/maas-build-actions@sha256:6182de169f2016eeab994aed8626edb1295d43720cd4485d43301d8e6b5c35fc \
             /bin/sh -c '. $VIRTUAL_ENV/bin/activate && cd $ACTIONS_PATH/sonarqube-hotspot-checker && python sonarqube_checker.py'

--- a/.github/workflows/hatch_release_security_checks.yml
+++ b/.github/workflows/hatch_release_security_checks.yml
@@ -72,7 +72,6 @@ jobs:
 
       - name: FOSSA Guard - Block on Policy Violations
         uses: SolaceDev/solace-public-workflows/.github/actions/fossa-guard@main
-        # if: github.ref_name == github.event.repository.default_branch && fromJson(inputs.fossa_check)
         continue-on-error: true
         with:
           fossa_api_key: ${{ secrets.FOSSA_API_KEY }}
@@ -85,7 +84,6 @@ jobs:
 
       - name: FOSSA Guard - Block on Security Vulnerabilities
         uses: SolaceDev/solace-public-workflows/.github/actions/fossa-guard@main
-        # if: github.ref_name == github.event.repository.default_branch && fromJson(inputs.fossa_check)
         continue-on-error: true
         with:
           fossa_api_key: ${{ secrets.FOSSA_API_KEY }}

--- a/.github/workflows/hatch_release_security_checks.yml
+++ b/.github/workflows/hatch_release_security_checks.yml
@@ -113,6 +113,7 @@ jobs:
           GH_REPO: ${{ github.event.repository.name }}
           GITHUB_SHA: ${{ github.sha }}
         run: |
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
           docker run --rm \
             -e AWS_ACCESS_KEY_ID \
             -e AWS_SECRET_ACCESS_KEY \
@@ -128,7 +129,7 @@ jobs:
             -e GH_ORG \
             -e GH_REPO \
             -e GITHUB_SHA \
-            ghcr.io/${{ github.repository_owner }}/maas-build-actions:latest \
+            ghcr.io/${OWNER}/maas-build-actions:latest \
             /bin/sh -c '. $VIRTUAL_ENV/bin/activate && cd $ACTIONS_PATH/prisma-vulnerability-checker && python prisma_vulnerability_checker.py'
 
       - name: Run SonarQube Hotspot Check
@@ -139,10 +140,11 @@ jobs:
           SONARQUBE_QUERY_TOKEN: ${{ secrets.SONARQUBE_QUERY_TOKEN }}
           SONARQUBE_HOTSPOTS_API_URL: ${{ secrets.SONARQUBE_HOTSPOTS_API_URL }}
         run: |
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
           docker run --rm \
             -e SONARQUBE_PROJECT_KEY \
             -e SONARQUBE_PROJECT_MAIN_BRANCH \
             -e SONARQUBE_QUERY_TOKEN \
             -e SONARQUBE_HOTSPOTS_API_URL \
-            ghcr.io/${{ github.repository_owner }}/maas-build-actions:latest \
+            ghcr.io/${OWNER}/maas-build-actions:latest \
             /bin/sh -c '. $VIRTUAL_ENV/bin/activate && cd $ACTIONS_PATH/sonarqube-hotspot-checker && python sonarqube_checker.py'


### PR DESCRIPTION
## Summary

- Converts `fossa-guard`, `cicd-helper`, and `generate-fossa-report` composite actions from `runs.using: docker` to `runs.using: composite` with explicit `docker run`
- Dynamically resolves the GitHub org from `github.repository_owner` (lowercased) instead of hardcoding `SolaceLabs` in the container image path
- Adds explicit GHCR authentication (`docker login ghcr.io`) before each `docker run` — required because composite actions do not auto-authenticate unlike `runs.using: docker`
- Adds `packages: read` to `hatch_release_security_checks.yml` and `hatch_release_pypi.yml` so the calling workflow's token can authenticate to GHCR
- Fixes FOSSA Guard composite action input/secret propagation and GitHub Actions secret over-masking of branch/project values

## Why

The previous `runs.using: docker` action type hardcoded the image org as `SolaceDev`, preventing orgs that use `maas-build-actions` under a different GitHub org from using these workflows. The new approach uses the calling workflow's `github.repository_owner` at runtime, making the image reference fully dynamic.

## Affected files

| File | Change |
|---|---|
| `.github/actions/fossa-guard/action.yaml` | Composite rewrite, dynamic org, GHCR auth, secret handling fixes |
| `.github/actions/cicd-helper/action.yaml` | Composite rewrite, dynamic org, GHCR auth |
| `.github/actions/generate-fossa-report/action.yaml` | Composite rewrite, dynamic org, GHCR auth |
| `.github/workflows/hatch_release_security_checks.yml` | Dynamic org, GHCR auth, `packages: read` |
| `.github/workflows/hatch_release_pypi.yml` | Dynamic org, GHCR auth, `packages: read` |

## Caller repo PRs

External repos calling these workflows need `packages: read` added to their permissions block before or alongside this merge. PRs raised:
- SolaceLabs/solace-ai-connector#147
- SolaceLabs/solace-agent-mesh-core-plugins#155 
`solace-agent-mesh` already has `packages: write` — no change needed.

## Notes

- The `build-finish-notifier` action reference in `container-scan-and-guard.yaml` remains hardcoded to `SolaceDev` (it's a `uses:` action reference, not a Docker pull) — migrating to a SPW equivalent is a follow-up


🤖 Generated with [Claude Code](https://claude.com/claude-code)