### PR TITLE
ci(DATAGO-131317): dynamic GitHub org for maas-build-actions image pull

### DIFF
--- a/.github/actions/cicd-helper/README.md
+++ b/.github/actions/cicd-helper/README.md
@@ -6,6 +6,19 @@ The `cicd-helper` GitHub Action is a reusable utility for CI/CD pipelines to aut
 
 ---
 
+## Caller Permissions
+
+This action runs the `maas-build-actions` container image from GHCR (`ghcr.io/<org>/maas-build-actions`). The calling workflow's `GITHUB_TOKEN` must have **at least `packages: read`** so that `docker login ghcr.io` can authenticate before pulling the image.
+
+```yaml
+permissions:
+  packages: read        # required to pull maas-build-actions image from GHCR
+```
+
+> **Note:** Composite actions cannot declare `permissions:` themselves. The calling workflow or job is fully responsible for granting this permission.
+
+---
+
 ## Usage
 
 ```yaml

--- a/.github/actions/cicd-helper/action.yaml
+++ b/.github/actions/cicd-helper/action.yaml
@@ -149,6 +149,10 @@ runs:
         [ -n "$DDB_OUTPUT_NAME" ] || unset DDB_OUTPUT_NAME
         [ -n "$DDB_RETURN_SECTION" ] || unset DDB_RETURN_SECTION
 
+        # GITHUB_OUTPUT and GITHUB_STEP_SUMMARY live under _runner_file_commands/,
+        # not under RUNNER_TEMP — mount their parent dir so the container can write outputs.
+        GITHUB_OUTPUT_DIR=$(dirname "$GITHUB_OUTPUT")
+
         docker run --rm \
           -e SLACK_TOKEN \
           -e SLACK_CHANNEL \
@@ -190,6 +194,7 @@ runs:
           -e GITHUB_STEP_SUMMARY \
           -v "${GITHUB_WORKSPACE}:/github/workspace" \
           -v "${RUNNER_TEMP}:${RUNNER_TEMP}" \
+          -v "${GITHUB_OUTPUT_DIR}:${GITHUB_OUTPUT_DIR}" \
           --workdir /github/workspace \
           "ghcr.io/${OWNER}/maas-build-actions@sha256:6182de169f2016eeab994aed8626edb1295d43720cd4485d43301d8e6b5c35fc" \
           /bin/sh -c 'source /maas-build-actions/venv/bin/activate && $RC_PYTHON $RC_HELPER_SCRIPT'

--- a/.github/actions/cicd-helper/action.yaml
+++ b/.github/actions/cicd-helper/action.yaml
@@ -90,82 +90,107 @@ inputs:
     required: false
 
 runs:
-  using: docker
-  image: docker://ghcr.io/solacedev/maas-build-actions:master
-  entrypoint: /bin/sh
-  args:
-    - -c
-    - |
-      export SLACK_TOKEN="$INPUT_SLACK_TOKEN"
-      export SLACK_CHANNEL="$INPUT_SLACK_CHANNEL"
-      export RC_STEP="$INPUT_RC_STEP"
-      export RC_PYTHON="python3"
-      export RC_HELPER_SCRIPT="/maas-build-actions/scripts/cicd-helper/cicd-helper.py"
-      if [ -n "$INPUT_THREAD_TS" ]; then export THREAD_TS="$INPUT_THREAD_TS"; fi
-      if [ -n "$INPUT_MESSAGE" ]; then export MESSAGE="$INPUT_MESSAGE"; fi
-      if [ -n "$INPUT_THREAD_MESSAGE" ]; then export THREAD_MESSAGE="$INPUT_THREAD_MESSAGE"; fi
-      if [ -n "$INPUT_MESSAGE_HEADER" ]; then export MESSAGE_HEADER="$INPUT_MESSAGE_HEADER"; fi
-      if [ -n "$INPUT_NEW_MESSAGE_HEADER" ]; then export NEW_MESSAGE_HEADER="$INPUT_NEW_MESSAGE_HEADER"; fi
-      if [ -n "$INPUT_CHANGE_LOG_HEADER_METADATA" ]; then export CHANGE_LOG_HEADER_METADATA="$INPUT_CHANGE_LOG_HEADER_METADATA"; fi
-      if [ -n "$INPUT_PREVIOUS_MESSAGE" ]; then export PREVIOUS_MESSAGE="$INPUT_PREVIOUS_MESSAGE"; fi
-      if [ -n "$INPUT_REPO_NAME" ]; then export REPO_NAME="$INPUT_REPO_NAME"; fi
-      if [ -n "$INPUT_DEPLOYED_REF" ]; then export DEPLOYED_REF="$INPUT_DEPLOYED_REF"; fi
-      if [ -n "$INPUT_CANDIDATE_REF" ]; then export CANDIDATE_REF="$INPUT_CANDIDATE_REF"; fi
-      if [ -n "$INPUT_CONTRIBUTORS_RAW_LIST" ]; then export CONTRIBUTORS_RAW_LIST="$INPUT_CONTRIBUTORS_RAW_LIST"; fi
-      if [ -n "$INPUT_DDB_ITEM_TO_BE_ADDED" ]; then export DDB_ITEM_TO_BE_ADDED="$INPUT_DDB_ITEM_TO_BE_ADDED"; fi
-      if [ -n "$INPUT_DDB_TABLE_NAME" ]; then export DDB_TABLE_NAME="$INPUT_DDB_TABLE_NAME"; fi
-      if [ -n "$INPUT_DDB_PARTITION_KEY" ]; then export DDB_PARTITION_KEY="$INPUT_DDB_PARTITION_KEY"; fi
-      if [ -n "$INPUT_DDB_SORT_KEY" ]; then export DDB_SORT_KEY="$INPUT_DDB_SORT_KEY"; fi
-      if [ -n "$INPUT_DDB_QUERY_JSON" ]; then export DDB_QUERY_JSON="$INPUT_DDB_QUERY_JSON"; fi
-      if [ -n "$INPUT_DDB_EXISTS_OUTPUT" ]; then export DDB_EXISTS_OUTPUT="$INPUT_DDB_EXISTS_OUTPUT"; fi
-      if [ -n "$INPUT_DDB_FIELD_PATH" ]; then export DDB_FIELD_PATH="$INPUT_DDB_FIELD_PATH"; fi
-      if [ -n "$INPUT_DDB_OUTPUT_NAME" ]; then export DDB_OUTPUT_NAME="$INPUT_DDB_OUTPUT_NAME"; fi
-      if [ -n "$INPUT_DDB_RETURN_SECTION" ]; then export DDB_RETURN_SECTION="$INPUT_DDB_RETURN_SECTION"; fi
-      if [ -n "$INPUT_THREAD_MESSAGE_TS" ]; then export THREAD_MESSAGE_TS="$INPUT_THREAD_MESSAGE_TS"; fi
-      if [ -n "$INPUT_NEW_THREAD_MESSAGE" ]; then export NEW_THREAD_MESSAGE="$INPUT_NEW_THREAD_MESSAGE"; fi
-      if [ -n "$INPUT_DDB_TABLE_INDEX_NAME" ]; then export DDB_TABLE_INDEX_NAME="$INPUT_DDB_TABLE_INDEX_NAME"; fi
-      if [ -n "$INPUT_DDB_INDEX_FIELD_NAME" ]; then export DDB_INDEX_FIELD_NAME="$INPUT_DDB_INDEX_FIELD_NAME"; fi
-      if [ -n "$INPUT_DDB_INDEX_FIELD_VALUE" ]; then export DDB_INDEX_FIELD_VALUE="$INPUT_DDB_INDEX_FIELD_VALUE"; fi
+  using: composite
+  steps:
+    - name: Run RC Helper
+      shell: bash
+      env:
+        # Inject all user-controlled inputs as OS environment variables so the
+        # bash script never sees their values substituted inline as script text.
+        # This prevents shell injection even if an input contains metacharacters.
+        SLACK_TOKEN: ${{ inputs.slack_token }}
+        SLACK_CHANNEL: ${{ inputs.slack_channel }}
+        RC_STEP: ${{ inputs.rc_step }}
+        THREAD_TS: ${{ inputs.thread_ts }}
+        MESSAGE: ${{ inputs.message }}
+        THREAD_MESSAGE: ${{ inputs.thread_message }}
+        MESSAGE_HEADER: ${{ inputs.message_header }}
+        NEW_MESSAGE_HEADER: ${{ inputs.new_message_header }}
+        CHANGE_LOG_HEADER_METADATA: ${{ inputs.change_log_header_metadata }}
+        PREVIOUS_MESSAGE: ${{ inputs.previous_message }}
+        REPO_NAME: ${{ inputs.repo_name }}
+        DEPLOYED_REF: ${{ inputs.deployed_ref }}
+        CANDIDATE_REF: ${{ inputs.candidate_ref }}
+        CONTRIBUTORS_RAW_LIST: ${{ inputs.contributors_raw_list }}
+        DDB_ITEM_TO_BE_ADDED: ${{ inputs.ddb_item_to_be_added }}
+        DDB_TABLE_NAME: ${{ inputs.ddb_table_name }}
+        DDB_PARTITION_KEY: ${{ inputs.ddb_partition_key }}
+        DDB_SORT_KEY: ${{ inputs.ddb_sort_key }}
+        DDB_QUERY_JSON: ${{ inputs.ddb_query_json }}
+        DDB_EXISTS_OUTPUT: ${{ inputs.ddb_exists_output }}
+        DDB_FIELD_PATH: ${{ inputs.ddb_field_path }}
+        DDB_OUTPUT_NAME: ${{ inputs.ddb_output_name }}
+        DDB_RETURN_SECTION: ${{ inputs.ddb_return_section }}
+        THREAD_MESSAGE_TS: ${{ inputs.thread_message_ts }}
+        NEW_THREAD_MESSAGE: ${{ inputs.new_thread_message }}
+        DDB_TABLE_INDEX_NAME: ${{ inputs.ddb_table_index_name }}
+        DDB_INDEX_FIELD_NAME: ${{ inputs.ddb_index_field_name }}
+        DDB_INDEX_FIELD_VALUE: ${{ inputs.ddb_index_field_value }}
+        AWS_REGION: ${{ inputs.aws_region }}
+      run: |
+        OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
 
+        # Authenticate to GHCR using the calling workflow's token so internal
+        # org packages can be pulled. runs.using: docker did this automatically;
+        # with composite + docker run we handle it explicitly.
+        # Use an isolated DOCKER_CONFIG to avoid persisting credentials on
+        # self-hosted runners' shared ~/.docker/config.json.
+        DOCKER_CONFIG=$(mktemp -d "${RUNNER_TEMP}/docker-config.XXXXXX")
+        export DOCKER_CONFIG
+        trap 'docker logout ghcr.io > /dev/null 2>&1 || true; rm -rf "${DOCKER_CONFIG}"' EXIT
+        echo "${{ github.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
+        export RC_PYTHON="python3"
+        export RC_HELPER_SCRIPT="/maas-build-actions/scripts/cicd-helper/cicd-helper.py"
+        export AWS_REGION="${AWS_REGION:-us-east-1}"
+        # Optional inputs with Python-side defaults: unset when empty so
+        # os.getenv(key, default) fallback in cicd-helper.py is preserved.
+        [ -n "$DDB_EXISTS_OUTPUT" ] || unset DDB_EXISTS_OUTPUT
+        [ -n "$DDB_OUTPUT_NAME" ] || unset DDB_OUTPUT_NAME
+        [ -n "$DDB_RETURN_SECTION" ] || unset DDB_RETURN_SECTION
 
-      # Set AWS_REGION, default to us-east-1 if not set
-      if [ -n "$INPUT_AWS_REGION" ]; then
-        export AWS_REGION="$INPUT_AWS_REGION"
-      else
-        export AWS_REGION="us-east-1"
-      fi
-
-      echo "Debug: Inputs:"
-      echo "RC_STEP: $RC_STEP"
-      echo "SLACK_TOKEN: [REDACTED]"
-      echo "SLACK_CHANNEL: $SLACK_CHANNEL"
-      echo "THREAD_TS: $THREAD_TS"
-      echo "MESSAGE: $MESSAGE"
-      echo "THREAD_MESSAGE: $THREAD_MESSAGE"
-      echo "NEW_MESSAGE_HEADER: $NEW_MESSAGE_HEADER"
-      echo "CHANGE_LOG_HEADER_METADATA: $CHANGE_LOG_HEADER_METADATA"
-      echo "PREVIOUS_MESSAGE: $PREVIOUS_MESSAGE"
-      echo "REPO_NAME: $REPO_NAME"
-      echo "DEPLOYED_REF: $DEPLOYED_REF"
-      echo "CANDIDATE_REF: $CANDIDATE_REF"
-      echo "DDB_ITEM_TO_BE_ADDED: $DDB_ITEM_TO_BE_ADDED"
-      echo "DDB_TABLE_NAME: $DDB_TABLE_NAME"
-      echo "DDB_PARTITION_KEY: $DDB_PARTITION_KEY"
-      echo "DDB_SORT_KEY: $DDB_SORT_KEY"
-      echo "DDB_QUERY_JSON: $DDB_QUERY_JSON"
-      echo "DDB_EXISTS_OUTPUT: $DDB_EXISTS_OUTPUT"
-      echo "CONTRIBUTORS_RAW_LIST: $CONTRIBUTORS_RAW_LIST"
-      echo "DDB_FIELD_PATH: $DDB_FIELD_PATH"
-      echo "DDB_OUTPUT_NAME: $DDB_OUTPUT_NAME"
-      echo "DDB_RETURN_SECTION: $DDB_RETURN_SECTION"
-      echo "AWS_REGION: $AWS_REGION"
-      echo "THREAD_MESSAGE_TS: $THREAD_MESSAGE_TS"
-      echo "NEW_THREAD_MESSAGE: $NEW_THREAD_MESSAGE"
-      echo "DDB_TABLE_INDEX_NAME: $DDB_TABLE_INDEX_NAME"
-      echo "DDB_INDEX_FIELD_NAME: $DDB_INDEX_FIELD_NAME"
-      echo "DDB_INDEX_FIELD_VALUE: $DDB_INDEX_FIELD_VALUE"
-
-      source /maas-build-actions/venv/bin/activate
-      $RC_PYTHON $RC_HELPER_SCRIPT
+        docker run --rm \
+          -e SLACK_TOKEN \
+          -e SLACK_CHANNEL \
+          -e RC_STEP \
+          -e RC_PYTHON \
+          -e RC_HELPER_SCRIPT \
+          -e THREAD_TS \
+          -e MESSAGE \
+          -e THREAD_MESSAGE \
+          -e MESSAGE_HEADER \
+          -e NEW_MESSAGE_HEADER \
+          -e CHANGE_LOG_HEADER_METADATA \
+          -e PREVIOUS_MESSAGE \
+          -e REPO_NAME \
+          -e DEPLOYED_REF \
+          -e CANDIDATE_REF \
+          -e CONTRIBUTORS_RAW_LIST \
+          -e DDB_ITEM_TO_BE_ADDED \
+          -e DDB_TABLE_NAME \
+          -e DDB_PARTITION_KEY \
+          -e DDB_SORT_KEY \
+          -e DDB_QUERY_JSON \
+          -e DDB_EXISTS_OUTPUT \
+          -e DDB_FIELD_PATH \
+          -e DDB_OUTPUT_NAME \
+          -e DDB_RETURN_SECTION \
+          -e THREAD_MESSAGE_TS \
+          -e NEW_THREAD_MESSAGE \
+          -e DDB_TABLE_INDEX_NAME \
+          -e DDB_INDEX_FIELD_NAME \
+          -e DDB_INDEX_FIELD_VALUE \
+          -e AWS_REGION \
+          -e AWS_ACCESS_KEY_ID \
+          -e AWS_SECRET_ACCESS_KEY \
+          -e AWS_SESSION_TOKEN \
+          -e GITHUB_TOKEN \
+          -e GITHUB_REPOSITORY \
+          -e GITHUB_OUTPUT \
+          -e GITHUB_STEP_SUMMARY \
+          -v "${GITHUB_WORKSPACE}:/github/workspace" \
+          -v "${RUNNER_TEMP}:${RUNNER_TEMP}" \
+          --workdir /github/workspace \
+          "ghcr.io/${OWNER}/maas-build-actions@sha256:6182de169f2016eeab994aed8626edb1295d43720cd4485d43301d8e6b5c35fc" \
+          /bin/sh -c 'source /maas-build-actions/venv/bin/activate && $RC_PYTHON $RC_HELPER_SCRIPT'
 

--- a/.github/actions/cicd-helper/action.yaml
+++ b/.github/actions/cicd-helper/action.yaml
@@ -89,10 +89,31 @@ inputs:
     description: "AWS region to use (optional, defaults to us-east-1 if not set)"
     required: false
 
+outputs:
+  # Outputs from post_to_channel
+  MAIN_SLACK_THREAD_TS:
+    description: "Timestamp of the main Slack channel message (use as thread_ts in subsequent steps)"
+    value: ${{ steps.run_rc_helper.outputs.MAIN_SLACK_THREAD_TS }}
+  MAIN_SLACK_MESSAGE:
+    description: "Text content of the main Slack channel message"
+    value: ${{ steps.run_rc_helper.outputs.MAIN_SLACK_MESSAGE }}
+  # Outputs from get_item_value_from_dynamodb
+  # The key name matches whatever ddb_output_name is set to by the caller.
+  # Add a new entry here for each distinct ddb_output_name value used across callers.
+  RC_VERSION:
+    description: "DynamoDB field value (when ddb_output_name=RC_VERSION)"
+    value: ${{ steps.run_rc_helper.outputs.RC_VERSION }}
+  # Outputs from item_exists_in_dynamodb
+  # The key name matches whatever ddb_exists_output is set to (default: ITEM_EXISTS).
+  ITEM_EXISTS:
+    description: "DynamoDB item existence flag (when ddb_exists_output=ITEM_EXISTS)"
+    value: ${{ steps.run_rc_helper.outputs.ITEM_EXISTS }}
+
 runs:
   using: composite
   steps:
     - name: Run RC Helper
+      id: run_rc_helper
       shell: bash
       env:
         # Inject all user-controlled inputs as OS environment variables so the

--- a/.github/actions/cicd-helper/action.yaml
+++ b/.github/actions/cicd-helper/action.yaml
@@ -217,6 +217,6 @@ runs:
           -v "${RUNNER_TEMP}:${RUNNER_TEMP}" \
           -v "${GITHUB_OUTPUT_DIR}:${GITHUB_OUTPUT_DIR}" \
           --workdir /github/workspace \
-          "ghcr.io/${OWNER}/maas-build-actions@sha256:6182de169f2016eeab994aed8626edb1295d43720cd4485d43301d8e6b5c35fc" \
+          "ghcr.io/${OWNER}/maas-build-actions@sha256:96f6a7276d96f888a1848db1d57715316054d0907471bd227a8eb737559fda3c" \
           /bin/sh -c 'source /maas-build-actions/venv/bin/activate && $RC_PYTHON $RC_HELPER_SCRIPT'
 

--- a/.github/actions/fossa-guard/README.md
+++ b/.github/actions/fossa-guard/README.md
@@ -4,6 +4,30 @@ The `fossa-guard` GitHub Action integrates with the FOSSA API to fetch and proce
 
 ---
 
+## Caller Permissions
+
+This action runs the `maas-build-actions` container image from GHCR (`ghcr.io/<org>/maas-build-actions`). The calling workflow's `GITHUB_TOKEN` must have **at least `packages: read`** so that `docker login ghcr.io` can authenticate before pulling the image.
+
+```yaml
+permissions:
+  packages: read        # required to pull maas-build-actions image from GHCR
+```
+
+If the calling workflow uses PR comments or status checks, also include:
+
+```yaml
+permissions:
+  packages: read        # required to pull maas-build-actions image from GHCR
+  pull-requests: write  # required for PR comments (enable_pr_comment)
+  issues: write         # required for PR comments (enable_pr_comment)
+  checks: write         # required for status checks (enable_status_check)
+  statuses: write       # required for commit status updates (enable_status_check)
+```
+
+> **Note:** Composite actions cannot declare `permissions:` themselves. The calling workflow or job is fully responsible for granting this permission.
+
+---
+
 ## Usage
 
 ```yaml
@@ -401,9 +425,10 @@ with:
 Add to workflow:
 ```yaml
 permissions:
-  pull-requests: write
-  checks: write
-  issues: write
+  packages: read        # required to pull maas-build-actions image from GHCR
+  pull-requests: write  # required for PR comments
+  checks: write         # required for status checks
+  issues: write         # required for PR comments
 ```
 
 ---

--- a/.github/actions/fossa-guard/action.yaml
+++ b/.github/actions/fossa-guard/action.yaml
@@ -86,67 +86,95 @@ inputs:
     default: "false"
 
 runs:
-  using: docker
-  image: docker://ghcr.io/solacedev/maas-build-actions:latest
-  entrypoint: /bin/sh
-  args:
-    - -c
-    - |
-      export FOSSA_API_KEY="$INPUT_FOSSA_API_KEY"
-      export FOSSA_PROJECT_ID="$INPUT_FOSSA_PROJECT_ID"
-      export FOSSA_CATEGORY="$INPUT_FOSSA_CATEGORY"
-      if [ -n "$INPUT_FOSSA_MODE" ]; then export FOSSA_MODE="$INPUT_FOSSA_MODE"; fi
-      if [ -n "$INPUT_BLOCK_ON" ]; then export BLOCK_ON="$INPUT_BLOCK_ON"; fi
-      if [ -n "$INPUT_FOSSA_BRANCH" ]; then export FOSSA_BRANCH="$INPUT_FOSSA_BRANCH"; fi
-      if [ -n "$INPUT_FOSSA_REVISION" ]; then export FOSSA_REVISION="$INPUT_FOSSA_REVISION"; fi
-      if [ -n "$INPUT_FOSSA_REVISION_SCAN_ID" ]; then export FOSSA_REVISION_SCAN_ID="$INPUT_FOSSA_REVISION_SCAN_ID"; fi
-      if [ -n "$INPUT_FOSSA_RELEASE" ]; then export FOSSA_RELEASE="$INPUT_FOSSA_RELEASE"; fi
-      if [ -n "$INPUT_FOSSA_RELEASE_SCAN_ID" ]; then export FOSSA_RELEASE_SCAN_ID="$INPUT_FOSSA_RELEASE_SCAN_ID"; fi
-      if [ -n "$INPUT_SLACK_TOKEN" ]; then export SLACK_TOKEN="$INPUT_SLACK_TOKEN"; fi
-      if [ -n "$INPUT_SLACK_CHANNEL" ]; then export SLACK_CHANNEL="$INPUT_SLACK_CHANNEL"; fi
-      if [ -n "$INPUT_SLACK_THREAD_TS" ]; then export SLACK_THREAD_TS="$INPUT_SLACK_THREAD_TS"; fi
-      if [ -n "$INPUT_GITHUB_REPOSITORY" ]; then export GITHUB_REPOSITORY="$INPUT_GITHUB_REPOSITORY"; fi
-      if [ -n "$INPUT_GITHUB_RUN_ID" ]; then export GITHUB_RUN_ID="$INPUT_GITHUB_RUN_ID"; fi
-      if [ -n "$INPUT_GITHUB_SERVER_URL" ]; then export GITHUB_SERVER_URL="$INPUT_GITHUB_SERVER_URL"; fi
-      if [ -n "$INPUT_GITHUB_TOKEN" ]; then export GITHUB_TOKEN="$INPUT_GITHUB_TOKEN"; fi
-      if [ -n "$INPUT_ENABLE_PR_COMMENT" ]; then export ENABLE_PR_COMMENT="$INPUT_ENABLE_PR_COMMENT"; fi
-      if [ -n "$INPUT_ENABLE_STATUS_CHECK" ]; then export ENABLE_STATUS_CHECK="$INPUT_ENABLE_STATUS_CHECK"; fi
-      if [ -n "$INPUT_STATUS_CHECK_NAME" ]; then export STATUS_CHECK_NAME="$INPUT_STATUS_CHECK_NAME"; fi
-      if [ -n "$INPUT_PR_COMMENT_MAX_VIOLATIONS" ]; then export PR_COMMENT_MAX_VIOLATIONS="$INPUT_PR_COMMENT_MAX_VIOLATIONS"; fi
-      if [ -n "$INPUT_ENABLE_DIFF_MODE" ]; then export ENABLE_DIFF_MODE="$INPUT_ENABLE_DIFF_MODE"; fi
-      if [ -n "$INPUT_DIFF_BASE_REVISION_SHA" ]; then export DIFF_BASE_REVISION_SHA="$INPUT_DIFF_BASE_REVISION_SHA"; fi
-      if [ -n "$INPUT_ENABLE_LICENSE_ENRICHMENT" ]; then export ENABLE_LICENSE_ENRICHMENT="$INPUT_ENABLE_LICENSE_ENRICHMENT"; fi
-      if [ -n "$INPUT_ENABLE_PRIVACY_MODE" ]; then export ENABLE_PRIVACY_MODE="$INPUT_ENABLE_PRIVACY_MODE"; fi
-      echo "Debug: Inputs:"
-      echo "FOSSA_API_KEY: [REDACTED]"
-      echo "FOSSA_PROJECT_ID: $FOSSA_PROJECT_ID"
-      echo "FOSSA_CATEGORY: $FOSSA_CATEGORY"
-      echo "FOSSA_MODE: $FOSSA_MODE"
-      echo "BLOCK_ON: $BLOCK_ON"
-      echo "FOSSA_BRANCH: $FOSSA_BRANCH"
-      echo "FOSSA_REVISION: $FOSSA_REVISION"
-      echo "FOSSA_REVISION_SCAN_ID: $FOSSA_REVISION_SCAN_ID"
-      echo "FOSSA_RELEASE: $FOSSA_RELEASE"
-      echo "FOSSA_RELEASE_SCAN_ID: $FOSSA_RELEASE_SCAN_ID"
-      echo "SLACK_TOKEN: [REDACTED]"
-      echo "SLACK_CHANNEL: $SLACK_CHANNEL"
-      echo "SLACK_THREAD_TS: $SLACK_THREAD_TS"
-      echo "GITHUB_REPOSITORY: $GITHUB_REPOSITORY"
-      echo "GITHUB_RUN_ID: $GITHUB_RUN_ID"
-      echo "GITHUB_SERVER_URL: $GITHUB_SERVER_URL"
-      echo "GITHUB_TOKEN: [REDACTED]"
-      echo "ENABLE_PR_COMMENT: $ENABLE_PR_COMMENT"
-      echo "ENABLE_STATUS_CHECK: $ENABLE_STATUS_CHECK"
-      echo "STATUS_CHECK_NAME: $STATUS_CHECK_NAME"
-      echo "PR_COMMENT_MAX_VIOLATIONS: $PR_COMMENT_MAX_VIOLATIONS"
-      echo "ENABLE_DIFF_MODE: $ENABLE_DIFF_MODE"
-      echo "DIFF_BASE_REVISION_SHA: $DIFF_BASE_REVISION_SHA"
-      echo "ENABLE_LICENSE_ENRICHMENT: $ENABLE_LICENSE_ENRICHMENT"
-      echo "ENABLE_PRIVACY_MODE: $ENABLE_PRIVACY_MODE"
-      echo "GITHUB_EVENT_NAME: $GITHUB_EVENT_NAME"
-      echo "GITHUB_REF: $GITHUB_REF"
-      echo "GITHUB_SHA: $GITHUB_SHA"
-      echo "GITHUB_HEAD_REF: $GITHUB_HEAD_REF"
-      echo "GITHUB_BASE_REF: $GITHUB_BASE_REF"
-      source /maas-build-actions/venv/bin/activate
-      python3 /maas-build-actions/scripts/fossa-guard/fossa_guard.py
+  using: composite
+  steps:
+    - name: Run Fossa Guard
+      shell: bash
+      run: |
+        OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+
+        # Authenticate to GHCR using the calling workflow's token so internal
+        # org packages can be pulled. runs.using: docker did this automatically;
+        # with composite + docker run we handle it explicitly.
+        # Use an isolated DOCKER_CONFIG to avoid persisting credentials on
+        # self-hosted runners' shared ~/.docker/config.json.
+        DOCKER_CONFIG=$(mktemp -d "${RUNNER_TEMP}/docker-config.XXXXXX")
+        export DOCKER_CONFIG
+        trap 'docker logout ghcr.io > /dev/null 2>&1 || true; rm -rf "${DOCKER_CONFIG}"' EXIT
+        echo "${{ github.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+        # Use ${{ inputs.xxx }} syntax for all inputs. INPUT_* env vars are not
+        # reliably set in composite action shell steps, so inline substitution
+        # is the only way to ensure values are passed.
+        # GITHUB_TOKEN is NOT exported here — it is already present in the
+        # runner environment (set automatically by GitHub Actions) and is
+        # inherited by the container via -e GITHUB_TOKEN without any inline
+        # substitution, preventing its value from over-masking other outputs.
+        export FOSSA_API_KEY="${{ inputs.fossa_api_key }}"
+        export FOSSA_PROJECT_ID="${{ inputs.fossa_project_id }}"
+        export FOSSA_CATEGORY="${{ inputs.fossa_category }}"
+        [ -n "${{ inputs.fossa_mode }}" ]               && export FOSSA_MODE="${{ inputs.fossa_mode }}"
+        [ -n "${{ inputs.block_on }}" ]                 && export BLOCK_ON="${{ inputs.block_on }}"
+        [ -n "${{ inputs.fossa_branch }}" ]             && export FOSSA_BRANCH="${{ inputs.fossa_branch }}"
+        [ -n "${{ inputs.fossa_revision }}" ]           && export FOSSA_REVISION="${{ inputs.fossa_revision }}"
+        [ -n "${{ inputs.fossa_revision_scan_id }}" ]   && export FOSSA_REVISION_SCAN_ID="${{ inputs.fossa_revision_scan_id }}"
+        [ -n "${{ inputs.fossa_release }}" ]            && export FOSSA_RELEASE="${{ inputs.fossa_release }}"
+        [ -n "${{ inputs.fossa_release_scan_id }}" ]    && export FOSSA_RELEASE_SCAN_ID="${{ inputs.fossa_release_scan_id }}"
+        [ -n "${{ inputs.slack_token }}" ]              && export SLACK_TOKEN="${{ inputs.slack_token }}"
+        [ -n "${{ inputs.slack_channel }}" ]            && export SLACK_CHANNEL="${{ inputs.slack_channel }}"
+        [ -n "${{ inputs.slack_thread_ts }}" ]          && export SLACK_THREAD_TS="${{ inputs.slack_thread_ts }}"
+        [ -n "${{ inputs.github_repository }}" ]        && export GITHUB_REPOSITORY="${{ inputs.github_repository }}"
+        [ -n "${{ inputs.github_run_id }}" ]            && export GITHUB_RUN_ID="${{ inputs.github_run_id }}"
+        [ -n "${{ inputs.github_server_url }}" ]        && export GITHUB_SERVER_URL="${{ inputs.github_server_url }}"
+        # GITHUB_TOKEN is inherited from the runner environment via -e GITHUB_TOKEN
+        # in the docker run below — no explicit export needed. Avoiding any
+        # inline expression substitution for the token prevents its value from
+        # being registered for masking (which would over-mask branch/project values).
+        [ -n "${{ inputs.enable_pr_comment }}" ]        && export ENABLE_PR_COMMENT="${{ inputs.enable_pr_comment }}"
+        [ -n "${{ inputs.enable_status_check }}" ]      && export ENABLE_STATUS_CHECK="${{ inputs.enable_status_check }}"
+        [ -n "${{ inputs.status_check_name }}" ]        && export STATUS_CHECK_NAME="${{ inputs.status_check_name }}"
+        [ -n "${{ inputs.pr_comment_max_violations }}" ] && export PR_COMMENT_MAX_VIOLATIONS="${{ inputs.pr_comment_max_violations }}"
+        [ -n "${{ inputs.enable_diff_mode }}" ]         && export ENABLE_DIFF_MODE="${{ inputs.enable_diff_mode }}"
+        [ -n "${{ inputs.diff_base_revision_sha }}" ]   && export DIFF_BASE_REVISION_SHA="${{ inputs.diff_base_revision_sha }}"
+        [ -n "${{ inputs.enable_license_enrichment }}" ] && export ENABLE_LICENSE_ENRICHMENT="${{ inputs.enable_license_enrichment }}"
+        [ -n "${{ inputs.enable_privacy_mode }}" ]      && export ENABLE_PRIVACY_MODE="${{ inputs.enable_privacy_mode }}"
+
+        docker run --rm \
+          -e FOSSA_API_KEY \
+          -e FOSSA_PROJECT_ID \
+          -e FOSSA_CATEGORY \
+          -e FOSSA_MODE \
+          -e BLOCK_ON \
+          -e FOSSA_BRANCH \
+          -e FOSSA_REVISION \
+          -e FOSSA_REVISION_SCAN_ID \
+          -e FOSSA_RELEASE \
+          -e FOSSA_RELEASE_SCAN_ID \
+          -e SLACK_TOKEN \
+          -e SLACK_CHANNEL \
+          -e SLACK_THREAD_TS \
+          -e GITHUB_REPOSITORY \
+          -e GITHUB_RUN_ID \
+          -e GITHUB_SERVER_URL \
+          -e GITHUB_TOKEN \
+          -e ENABLE_PR_COMMENT \
+          -e ENABLE_STATUS_CHECK \
+          -e STATUS_CHECK_NAME \
+          -e PR_COMMENT_MAX_VIOLATIONS \
+          -e ENABLE_DIFF_MODE \
+          -e DIFF_BASE_REVISION_SHA \
+          -e ENABLE_LICENSE_ENRICHMENT \
+          -e ENABLE_PRIVACY_MODE \
+          -e GITHUB_REF \
+          -e GITHUB_SHA \
+          -e GITHUB_HEAD_REF \
+          -e GITHUB_BASE_REF \
+          -e GITHUB_EVENT_NAME \
+          -e GITHUB_EVENT_PATH \
+          -e GITHUB_OUTPUT \
+          -e GITHUB_STEP_SUMMARY \
+          -v "${GITHUB_WORKSPACE}:/github/workspace" \
+          -v "${RUNNER_TEMP}:${RUNNER_TEMP}" \
+          --workdir /github/workspace \
+          "ghcr.io/${OWNER}/maas-build-actions@sha256:6182de169f2016eeab994aed8626edb1295d43720cd4485d43301d8e6b5c35fc" \
+          /bin/sh -c 'source /maas-build-actions/venv/bin/activate && python3 /maas-build-actions/scripts/fossa-guard/fossa_guard.py'

--- a/.github/actions/fossa-guard/action.yaml
+++ b/.github/actions/fossa-guard/action.yaml
@@ -181,5 +181,5 @@ runs:
           -v "${RUNNER_TEMP}:${RUNNER_TEMP}" \
           -v "${GITHUB_OUTPUT_DIR}:${GITHUB_OUTPUT_DIR}" \
           --workdir /github/workspace \
-          "ghcr.io/${OWNER}/maas-build-actions@sha256:6182de169f2016eeab994aed8626edb1295d43720cd4485d43301d8e6b5c35fc" \
+          "ghcr.io/${OWNER}/maas-build-actions@sha256:96f6a7276d96f888a1848db1d57715316054d0907471bd227a8eb737559fda3c" \
           /bin/sh -c 'source /maas-build-actions/venv/bin/activate && python3 /maas-build-actions/scripts/fossa-guard/fossa_guard.py'

--- a/.github/actions/fossa-guard/action.yaml
+++ b/.github/actions/fossa-guard/action.yaml
@@ -139,6 +139,10 @@ runs:
         [ -n "${{ inputs.enable_license_enrichment }}" ] && export ENABLE_LICENSE_ENRICHMENT="${{ inputs.enable_license_enrichment }}"
         [ -n "${{ inputs.enable_privacy_mode }}" ]      && export ENABLE_PRIVACY_MODE="${{ inputs.enable_privacy_mode }}"
 
+        # GITHUB_OUTPUT and GITHUB_STEP_SUMMARY live under _runner_file_commands/,
+        # not under RUNNER_TEMP — mount their parent dir so the container can write outputs.
+        GITHUB_OUTPUT_DIR=$(dirname "$GITHUB_OUTPUT")
+
         docker run --rm \
           -e FOSSA_API_KEY \
           -e FOSSA_PROJECT_ID \
@@ -175,6 +179,7 @@ runs:
           -e GITHUB_STEP_SUMMARY \
           -v "${GITHUB_WORKSPACE}:/github/workspace" \
           -v "${RUNNER_TEMP}:${RUNNER_TEMP}" \
+          -v "${GITHUB_OUTPUT_DIR}:${GITHUB_OUTPUT_DIR}" \
           --workdir /github/workspace \
           "ghcr.io/${OWNER}/maas-build-actions@sha256:6182de169f2016eeab994aed8626edb1295d43720cd4485d43301d8e6b5c35fc" \
           /bin/sh -c 'source /maas-build-actions/venv/bin/activate && python3 /maas-build-actions/scripts/fossa-guard/fossa_guard.py'

--- a/.github/actions/generate-fossa-report/README.md
+++ b/.github/actions/generate-fossa-report/README.md
@@ -2,6 +2,19 @@
 
 This action generates and downloads FOSSA attribution reports.
 
+## Caller Permissions
+
+This action runs the `maas-build-actions` container image from GHCR (`ghcr.io/<org>/maas-build-actions`). The calling workflow's `GITHUB_TOKEN` must have **at least `packages: read`** so that `docker login ghcr.io` can authenticate before pulling the image.
+
+```yaml
+permissions:
+  packages: read        # required to pull maas-build-actions image from GHCR
+```
+
+> **Note:** Composite actions cannot declare `permissions:` themselves. The calling workflow or job is fully responsible for granting this permission.
+
+---
+
 ## Usage
 
 ```yaml

--- a/.github/actions/generate-fossa-report/action.yaml
+++ b/.github/actions/generate-fossa-report/action.yaml
@@ -97,5 +97,5 @@ runs:
           -v "${RUNNER_TEMP}:${RUNNER_TEMP}" \
           -v "${GITHUB_OUTPUT_DIR}:${GITHUB_OUTPUT_DIR}" \
           --workdir /github/workspace \
-          "ghcr.io/${OWNER}/maas-build-actions@sha256:6182de169f2016eeab994aed8626edb1295d43720cd4485d43301d8e6b5c35fc" \
+          "ghcr.io/${OWNER}/maas-build-actions@sha256:96f6a7276d96f888a1848db1d57715316054d0907471bd227a8eb737559fda3c" \
           /bin/sh -c 'bash /maas-build-actions/actions/generate-fossa-report/generate-report.sh'

--- a/.github/actions/generate-fossa-report/action.yaml
+++ b/.github/actions/generate-fossa-report/action.yaml
@@ -41,34 +41,56 @@ inputs:
     required: false
 
 runs:
-  using: docker
-  image: docker://ghcr.io/solacedev/maas-build-actions:latest
-  entrypoint: /bin/sh
-  args:
-    - -c
-    - |
-      export FOSSA_API_KEY="$INPUT_FOSSA_API_KEY"
-      export ORG_ID="$INPUT_ORG_ID"
-      if [ -n "$INPUT_PROJECT_LOCATOR" ]; then export PROJECT_LOCATOR="$INPUT_PROJECT_LOCATOR"; fi
-      export FOSSA_CONFIG_FILE="$INPUT_FOSSA_CONFIG_FILE"
-      if [ -n "$INPUT_REVISION_ID" ]; then export REVISION_ID="$INPUT_REVISION_ID"; fi
-      if [ -n "$INPUT_RELEASE_GROUP_ID" ]; then export RELEASE_GROUP_ID="$INPUT_RELEASE_GROUP_ID"; fi
-      if [ -n "$INPUT_RELEASE_ID" ]; then export RELEASE_ID="$INPUT_RELEASE_ID"; fi
-      export FORMAT="$INPUT_FORMAT"
-      export OUTPUT_FILE="$INPUT_OUTPUT_FILE"
-      export REPORT_PROFILE="$INPUT_REPORT_PROFILE"
-      if [ -n "$INPUT_REPORT_PARAMETERS" ]; then export REPORT_PARAMETERS="$INPUT_REPORT_PARAMETERS"; fi
+  using: composite
+  steps:
+    - name: Generate FOSSA Report
+      shell: bash
+      env:
+        # Inject all user-controlled inputs as OS environment variables so the
+        # bash script never sees their values substituted inline as script text.
+        # This prevents shell injection even if an input contains metacharacters.
+        FOSSA_API_KEY: ${{ inputs.fossa_api_key }}
+        ORG_ID: ${{ inputs.org_id }}
+        FOSSA_CONFIG_FILE: ${{ inputs.fossa_config_file }}
+        FORMAT: ${{ inputs.format }}
+        OUTPUT_FILE: ${{ inputs.output_file }}
+        REPORT_PROFILE: ${{ inputs.report_profile }}
+        PROJECT_LOCATOR: ${{ inputs.project_locator }}
+        REVISION_ID: ${{ inputs.revision_id }}
+        RELEASE_GROUP_ID: ${{ inputs.release_group_id }}
+        RELEASE_ID: ${{ inputs.release_id }}
+        REPORT_PARAMETERS: ${{ inputs.report_parameters }}
+      run: |
+        OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
 
-      echo "Generating FOSSA report..."
-      if [ -n "$RELEASE_GROUP_ID" ]; then
-        echo "Release Group ID: $RELEASE_GROUP_ID"
-        echo "Release ID: $RELEASE_ID"
-      else
-        echo "Project: $ORG_ID/$PROJECT_LOCATOR"
-        echo "Revision: $REVISION_ID"
-      fi
-      echo "Format: $FORMAT"
-      echo "Profile: $REPORT_PROFILE"
-      echo "Output: $OUTPUT_FILE"
+        # Authenticate to GHCR using the calling workflow's token so internal
+        # org packages can be pulled. runs.using: docker did this automatically;
+        # with composite + docker run we handle it explicitly.
+        # Use an isolated DOCKER_CONFIG to avoid persisting credentials on
+        # self-hosted runners' shared ~/.docker/config.json.
+        DOCKER_CONFIG=$(mktemp -d "${RUNNER_TEMP}/docker-config.XXXXXX")
+        export DOCKER_CONFIG
+        trap 'docker logout ghcr.io > /dev/null 2>&1 || true; rm -rf "${DOCKER_CONFIG}"' EXIT
+        echo "${{ github.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
-      bash /maas-build-actions/actions/generate-fossa-report/generate-report.sh
+        # All inputs are already in the environment via the env: block above.
+
+        docker run --rm \
+          -e FOSSA_API_KEY \
+          -e ORG_ID \
+          -e FOSSA_CONFIG_FILE \
+          -e FORMAT \
+          -e OUTPUT_FILE \
+          -e REPORT_PROFILE \
+          -e PROJECT_LOCATOR \
+          -e REVISION_ID \
+          -e RELEASE_GROUP_ID \
+          -e RELEASE_ID \
+          -e REPORT_PARAMETERS \
+          -e GITHUB_OUTPUT \
+          -e GITHUB_STEP_SUMMARY \
+          -v "${GITHUB_WORKSPACE}:/github/workspace" \
+          -v "${RUNNER_TEMP}:${RUNNER_TEMP}" \
+          --workdir /github/workspace \
+          "ghcr.io/${OWNER}/maas-build-actions@sha256:6182de169f2016eeab994aed8626edb1295d43720cd4485d43301d8e6b5c35fc" \
+          /bin/sh -c 'bash /maas-build-actions/actions/generate-fossa-report/generate-report.sh'

--- a/.github/actions/generate-fossa-report/action.yaml
+++ b/.github/actions/generate-fossa-report/action.yaml
@@ -75,6 +75,10 @@ runs:
 
         # All inputs are already in the environment via the env: block above.
 
+        # GITHUB_OUTPUT and GITHUB_STEP_SUMMARY live under _runner_file_commands/,
+        # not under RUNNER_TEMP — mount their parent dir so the container can write outputs.
+        GITHUB_OUTPUT_DIR=$(dirname "$GITHUB_OUTPUT")
+
         docker run --rm \
           -e FOSSA_API_KEY \
           -e ORG_ID \
@@ -91,6 +95,7 @@ runs:
           -e GITHUB_STEP_SUMMARY \
           -v "${GITHUB_WORKSPACE}:/github/workspace" \
           -v "${RUNNER_TEMP}:${RUNNER_TEMP}" \
+          -v "${GITHUB_OUTPUT_DIR}:${GITHUB_OUTPUT_DIR}" \
           --workdir /github/workspace \
           "ghcr.io/${OWNER}/maas-build-actions@sha256:6182de169f2016eeab994aed8626edb1295d43720cd4485d43301d8e6b5c35fc" \
           /bin/sh -c 'bash /maas-build-actions/actions/generate-fossa-report/generate-report.sh'

--- a/.github/workflows/container-scan-and-guard.yaml
+++ b/.github/workflows/container-scan-and-guard.yaml
@@ -108,6 +108,7 @@ permissions:
   pull-requests: write
   id-token: write
   checks: write
+  packages: read
 
 jobs:
   container_scan:

--- a/.github/workflows/hatch_ci.yml
+++ b/.github/workflows/hatch_ci.yml
@@ -93,6 +93,7 @@ permissions:
   pull-requests: write
   checks: write
   contents: write
+  packages: read
 
 concurrency:
   # Only run once for latest commit per ref and cancel other (previous) runs.

--- a/.github/workflows/hatch_release_pypi.yml
+++ b/.github/workflows/hatch_release_pypi.yml
@@ -105,6 +105,7 @@ permissions:
   contents: write
   checks: write
   pull-requests: read
+  packages: read
 
 jobs:
   release:
@@ -124,7 +125,6 @@ jobs:
 
       - name: Run Prisma Check
         if: ${{ fromJson(inputs.prisma_check) }}
-        uses: docker://ghcr.io/solacedev/maas-build-actions:latest
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.MANIFEST_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.MANIFEST_AWS_SECRET_ACCESS_KEY }}
@@ -140,28 +140,49 @@ jobs:
           GH_ORG: ${{ github.repository_owner }}
           GH_REPO: ${{ github.event.repository.name }}
           GITHUB_SHA: ${{ github.sha }}
-        with:
-          entrypoint: /bin/sh
-          args: >
-            -c ". $VIRTUAL_ENV/bin/activate &&
-            cd $ACTIONS_PATH/prisma-vulnerability-checker &&
-            python prisma_vulnerability_checker.py
-            "
+        run: |
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          DOCKER_CONFIG=$(mktemp -d "${RUNNER_TEMP}/docker-config.XXXXXX")
+          export DOCKER_CONFIG
+          trap 'docker logout ghcr.io > /dev/null 2>&1 || true; rm -rf "${DOCKER_CONFIG}"' EXIT
+          echo "${{ github.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          docker run --rm \
+            -e AWS_ACCESS_KEY_ID \
+            -e AWS_SECRET_ACCESS_KEY \
+            -e PRISMA_REPOSITORY_NAME \
+            -e DOCKER_IMAGE_TO_CHECK \
+            -e PRISMA_ACCESS_KEY_ID \
+            -e PRISMA_ACCESS_KEY_SECRET \
+            -e PRISMA_JIRA_CHECK \
+            -e AWS_REGION \
+            -e JIRA_ONLY \
+            -e STATUS_CHECK \
+            -e GH_TOKEN \
+            -e GH_ORG \
+            -e GH_REPO \
+            -e GITHUB_SHA \
+            ghcr.io/${OWNER}/maas-build-actions@sha256:6182de169f2016eeab994aed8626edb1295d43720cd4485d43301d8e6b5c35fc \
+            /bin/sh -c '. $VIRTUAL_ENV/bin/activate && cd $ACTIONS_PATH/prisma-vulnerability-checker && python prisma_vulnerability_checker.py'
       - name: Run SonarQube Hotspot Check
-        uses: docker://ghcr.io/solacedev/maas-build-actions:latest
         if: ${{ fromJson(inputs.sonarqube_hotspot_check) }}
         env:
           SONARQUBE_PROJECT_KEY: ${{ secrets.SONARQUBE_PROJECT_KEY }}
           SONARQUBE_PROJECT_MAIN_BRANCH: ${{ secrets.SONARQUBE_PROJECT_MAIN_BRANCH }}
           SONARQUBE_QUERY_TOKEN: ${{ secrets.SONARQUBE_QUERY_TOKEN }}
           SONARQUBE_HOTSPOTS_API_URL: ${{ secrets.SONARQUBE_HOTSPOTS_API_URL }}
-        with:
-          entrypoint: /bin/sh
-          args: >
-            -c ". $VIRTUAL_ENV/bin/activate &&
-            cd $ACTIONS_PATH/sonarqube-hotspot-checker &&
-            python sonarqube_checker.py
-            "
+        run: |
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          DOCKER_CONFIG=$(mktemp -d "${RUNNER_TEMP}/docker-config.XXXXXX")
+          export DOCKER_CONFIG
+          trap 'docker logout ghcr.io > /dev/null 2>&1 || true; rm -rf "${DOCKER_CONFIG}"' EXIT
+          echo "${{ github.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          docker run --rm \
+            -e SONARQUBE_PROJECT_KEY \
+            -e SONARQUBE_PROJECT_MAIN_BRANCH \
+            -e SONARQUBE_QUERY_TOKEN \
+            -e SONARQUBE_HOTSPOTS_API_URL \
+            ghcr.io/${OWNER}/maas-build-actions@sha256:6182de169f2016eeab994aed8626edb1295d43720cd4485d43301d8e6b5c35fc \
+            /bin/sh -c '. $VIRTUAL_ENV/bin/activate && cd $ACTIONS_PATH/sonarqube-hotspot-checker && python sonarqube_checker.py'
 
       - name: Setup Node.js
         if: inputs.npm_package_path != ''

--- a/.github/workflows/hatch_release_pypi.yml
+++ b/.github/workflows/hatch_release_pypi.yml
@@ -161,7 +161,7 @@ jobs:
             -e GH_ORG \
             -e GH_REPO \
             -e GITHUB_SHA \
-            ghcr.io/${OWNER}/maas-build-actions@sha256:6182de169f2016eeab994aed8626edb1295d43720cd4485d43301d8e6b5c35fc \
+            ghcr.io/${OWNER}/maas-build-actions@sha256:96f6a7276d96f888a1848db1d57715316054d0907471bd227a8eb737559fda3c \
             /bin/sh -c '. $VIRTUAL_ENV/bin/activate && cd $ACTIONS_PATH/prisma-vulnerability-checker && python prisma_vulnerability_checker.py'
       - name: Run SonarQube Hotspot Check
         if: ${{ fromJson(inputs.sonarqube_hotspot_check) }}
@@ -181,7 +181,7 @@ jobs:
             -e SONARQUBE_PROJECT_MAIN_BRANCH \
             -e SONARQUBE_QUERY_TOKEN \
             -e SONARQUBE_HOTSPOTS_API_URL \
-            ghcr.io/${OWNER}/maas-build-actions@sha256:6182de169f2016eeab994aed8626edb1295d43720cd4485d43301d8e6b5c35fc \
+            ghcr.io/${OWNER}/maas-build-actions@sha256:96f6a7276d96f888a1848db1d57715316054d0907471bd227a8eb737559fda3c \
             /bin/sh -c '. $VIRTUAL_ENV/bin/activate && cd $ACTIONS_PATH/sonarqube-hotspot-checker && python sonarqube_checker.py'
 
       - name: Setup Node.js

--- a/.github/workflows/hatch_release_security_checks.yml
+++ b/.github/workflows/hatch_release_security_checks.yml
@@ -57,6 +57,7 @@ permissions:
   contents: read
   checks: write
   pull-requests: read
+  packages: read
 
 jobs:
   security-checks:
@@ -70,8 +71,8 @@ jobs:
           fetch-depth: 0
 
       - name: FOSSA Guard - Block on Policy Violations
+        if: ${{ fromJson(inputs.fossa_check) }}
         uses: SolaceDev/solace-public-workflows/.github/actions/fossa-guard@main
-        if: github.ref_name == github.event.repository.default_branch && fromJson(inputs.fossa_check)
         continue-on-error: true
         with:
           fossa_api_key: ${{ secrets.FOSSA_API_KEY }}
@@ -83,8 +84,8 @@ jobs:
           block_on: policy_conflict
 
       - name: FOSSA Guard - Block on Security Vulnerabilities
+        if: ${{ fromJson(inputs.fossa_check) }}
         uses: SolaceDev/solace-public-workflows/.github/actions/fossa-guard@main
-        if: github.ref_name == github.event.repository.default_branch && fromJson(inputs.fossa_check)
         continue-on-error: true
         with:
           fossa_api_key: ${{ secrets.FOSSA_API_KEY }}
@@ -97,7 +98,6 @@ jobs:
 
       - name: Run Prisma Check
         if: ${{ fromJson(inputs.prisma_check) }}
-        uses: docker://ghcr.io/solacedev/maas-build-actions:latest
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.MANIFEST_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.MANIFEST_AWS_SECRET_ACCESS_KEY }}
@@ -113,26 +113,47 @@ jobs:
           GH_ORG: ${{ github.repository_owner }}
           GH_REPO: ${{ github.event.repository.name }}
           GITHUB_SHA: ${{ github.sha }}
-        with:
-          entrypoint: /bin/sh
-          args: >
-            -c ". $VIRTUAL_ENV/bin/activate &&
-            cd $ACTIONS_PATH/prisma-vulnerability-checker &&
-            python prisma_vulnerability_checker.py
-            "
+        run: |
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          DOCKER_CONFIG=$(mktemp -d "${RUNNER_TEMP}/docker-config.XXXXXX")
+          export DOCKER_CONFIG
+          trap 'docker logout ghcr.io > /dev/null 2>&1 || true; rm -rf "${DOCKER_CONFIG}"' EXIT
+          echo "${{ github.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          docker run --rm \
+            -e AWS_ACCESS_KEY_ID \
+            -e AWS_SECRET_ACCESS_KEY \
+            -e PRISMA_REPOSITORY_NAME \
+            -e DOCKER_IMAGE_TO_CHECK \
+            -e PRISMA_ACCESS_KEY_ID \
+            -e PRISMA_ACCESS_KEY_SECRET \
+            -e PRISMA_JIRA_CHECK \
+            -e AWS_REGION \
+            -e JIRA_ONLY \
+            -e STATUS_CHECK \
+            -e GH_TOKEN \
+            -e GH_ORG \
+            -e GH_REPO \
+            -e GITHUB_SHA \
+            ghcr.io/${OWNER}/maas-build-actions@sha256:6182de169f2016eeab994aed8626edb1295d43720cd4485d43301d8e6b5c35fc \
+            /bin/sh -c '. $VIRTUAL_ENV/bin/activate && cd $ACTIONS_PATH/prisma-vulnerability-checker && python prisma_vulnerability_checker.py'
 
       - name: Run SonarQube Hotspot Check
-        uses: docker://ghcr.io/solacedev/maas-build-actions:latest
         if: ${{ fromJson(inputs.sonarqube_hotspot_check) }}
         env:
           SONARQUBE_PROJECT_KEY: ${{ secrets.SONARQUBE_PROJECT_KEY }}
           SONARQUBE_PROJECT_MAIN_BRANCH: ${{ secrets.SONARQUBE_PROJECT_MAIN_BRANCH }}
           SONARQUBE_QUERY_TOKEN: ${{ secrets.SONARQUBE_QUERY_TOKEN }}
           SONARQUBE_HOTSPOTS_API_URL: ${{ secrets.SONARQUBE_HOTSPOTS_API_URL }}
-        with:
-          entrypoint: /bin/sh
-          args: >
-            -c ". $VIRTUAL_ENV/bin/activate &&
-            cd $ACTIONS_PATH/sonarqube-hotspot-checker &&
-            python sonarqube_checker.py
-            "
+        run: |
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          DOCKER_CONFIG=$(mktemp -d "${RUNNER_TEMP}/docker-config.XXXXXX")
+          export DOCKER_CONFIG
+          trap 'docker logout ghcr.io > /dev/null 2>&1 || true; rm -rf "${DOCKER_CONFIG}"' EXIT
+          echo "${{ github.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          docker run --rm \
+            -e SONARQUBE_PROJECT_KEY \
+            -e SONARQUBE_PROJECT_MAIN_BRANCH \
+            -e SONARQUBE_QUERY_TOKEN \
+            -e SONARQUBE_HOTSPOTS_API_URL \
+            ghcr.io/${OWNER}/maas-build-actions@sha256:6182de169f2016eeab994aed8626edb1295d43720cd4485d43301d8e6b5c35fc \
+            /bin/sh -c '. $VIRTUAL_ENV/bin/activate && cd $ACTIONS_PATH/sonarqube-hotspot-checker && python sonarqube_checker.py'

--- a/.github/workflows/hatch_release_security_checks.yml
+++ b/.github/workflows/hatch_release_security_checks.yml
@@ -136,7 +136,7 @@ jobs:
             -e GH_ORG \
             -e GH_REPO \
             -e GITHUB_SHA \
-            ghcr.io/${OWNER}/maas-build-actions@sha256:6182de169f2016eeab994aed8626edb1295d43720cd4485d43301d8e6b5c35fc \
+            ghcr.io/${OWNER}/maas-build-actions@sha256:96f6a7276d96f888a1848db1d57715316054d0907471bd227a8eb737559fda3c \
             /bin/sh -c '. $VIRTUAL_ENV/bin/activate && cd $ACTIONS_PATH/prisma-vulnerability-checker && python prisma_vulnerability_checker.py'
 
       - name: Run SonarQube Hotspot Check
@@ -159,5 +159,5 @@ jobs:
             -e SONARQUBE_PROJECT_MAIN_BRANCH \
             -e SONARQUBE_QUERY_TOKEN \
             -e SONARQUBE_HOTSPOTS_API_URL \
-            ghcr.io/${OWNER}/maas-build-actions@sha256:6182de169f2016eeab994aed8626edb1295d43720cd4485d43301d8e6b5c35fc \
+            ghcr.io/${OWNER}/maas-build-actions@sha256:96f6a7276d96f888a1848db1d57715316054d0907471bd227a8eb737559fda3c \
             /bin/sh -c '. $VIRTUAL_ENV/bin/activate && cd $ACTIONS_PATH/sonarqube-hotspot-checker && python sonarqube_checker.py'

--- a/.github/workflows/hatch_release_security_checks.yml
+++ b/.github/workflows/hatch_release_security_checks.yml
@@ -115,6 +115,8 @@ jobs:
           GITHUB_SHA: ${{ github.sha }}
         run: |
           OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          # XXXXXX is a mktemp template — replaced with random chars to create a unique dir.
+          # Isolates Docker credentials from the shared ~/.docker/config.json on self-hosted runners.
           DOCKER_CONFIG=$(mktemp -d "${RUNNER_TEMP}/docker-config.XXXXXX")
           export DOCKER_CONFIG
           trap 'docker logout ghcr.io > /dev/null 2>&1 || true; rm -rf "${DOCKER_CONFIG}"' EXIT
@@ -146,6 +148,8 @@ jobs:
           SONARQUBE_HOTSPOTS_API_URL: ${{ secrets.SONARQUBE_HOTSPOTS_API_URL }}
         run: |
           OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          # XXXXXX is a mktemp template — replaced with random chars to create a unique dir.
+          # Isolates Docker credentials from the shared ~/.docker/config.json on self-hosted runners.
           DOCKER_CONFIG=$(mktemp -d "${RUNNER_TEMP}/docker-config.XXXXXX")
           export DOCKER_CONFIG
           trap 'docker logout ghcr.io > /dev/null 2>&1 || true; rm -rf "${DOCKER_CONFIG}"' EXIT

--- a/.github/workflows/hatch_release_security_checks.yml
+++ b/.github/workflows/hatch_release_security_checks.yml
@@ -71,7 +71,7 @@ jobs:
           fetch-depth: 0
 
       - name: FOSSA Guard - Block on Policy Violations
-        if: ${{ fromJson(inputs.fossa_check) }}
+        if: github.ref_name == github.event.repository.default_branch && fromJson(inputs.fossa_check)
         uses: SolaceDev/solace-public-workflows/.github/actions/fossa-guard@main
         continue-on-error: true
         with:
@@ -84,7 +84,7 @@ jobs:
           block_on: policy_conflict
 
       - name: FOSSA Guard - Block on Security Vulnerabilities
-        if: ${{ fromJson(inputs.fossa_check) }}
+        if: github.ref_name == github.event.repository.default_branch && fromJson(inputs.fossa_check)
         uses: SolaceDev/solace-public-workflows/.github/actions/fossa-guard@main
         continue-on-error: true
         with:

--- a/.github/workflows/sca-scan-and-guard.yaml
+++ b/.github/workflows/sca-scan-and-guard.yaml
@@ -154,6 +154,7 @@ permissions:
   actions: read
   checks: write
   statuses: write
+  packages: read
 
 jobs:
   sca_scan:


### PR DESCRIPTION
## Summary

- Migrates composite actions (`fossa-guard`, `cicd-helper`, `generate-fossa-report`) from `runs.using: docker` to `runs.using: composite` with explicit `docker login ghcr.io` + `docker run`
- Replaces hardcoded `ghcr.io/solacedev/` org with dynamic org derived from `github.repository_owner` (lowercased), so the actions work from any GitHub org (`SolaceDev`, `SolaceLabs`, `SolaceProducts`)
- Pins `maas-build-actions` image to a SHA digest instead of mutable `:latest`/`:master` tags
- Adds `packages: read` to all internal reusable workflows (`sca-scan-and-guard`, `container-scan-and-guard`, `hatch_ci`, `hatch_release_pypi`, `hatch_release_security_checks`) — required for `docker login ghcr.io` to succeed in the composite actions
- Migrates Prisma vulnerability checker steps in `hatch_release_pypi` and `hatch_release_security_checks` from `uses: docker://...` to `run:` with explicit docker login

## Context

This re-introduces [PR #90](https://github.com/SolaceDev/solace-public-workflows/pull/90) (reverted in #91) with additional fixes for secret masking, input handling, and GHCR authentication in composite actions.

Callers of these composite actions must have `packages: read` (or `packages: write`) on their `GITHUB_TOKEN` — see `docs/github-actions-permissions-model.md` for the full inheritance model.

## Files changed

| File | Change |
|---|---|
| `.github/actions/fossa-guard/action.yaml` | `using: docker` → `using: composite`; dynamic org; SHA-pinned image |
| `.github/actions/cicd-helper/action.yaml` | Same migration |
| `.github/actions/generate-fossa-report/action.yaml` | Same migration |
| `.github/workflows/hatch_release_pypi.yml` | `packages: read`; Prisma step migrated |
| `.github/workflows/hatch_release_security_checks.yml` | `packages: read`; Prisma step migrated |
| `.github/workflows/sca-scan-and-guard.yaml` | `packages: read` |
| `.github/workflows/container-scan-and-guard.yaml` | `packages: read` |
| `.github/workflows/hatch_ci.yml` | `packages: read` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)