### PR TITLE
feat(DATAGO-132302): add workflow dispatch action

### DIFF
--- a/common/github_reporting.py
+++ b/common/github_reporting.py
@@ -34,7 +34,7 @@ def github_api(
     headers = {
         "Authorization": f"Bearer {token}",
         "Accept": "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
+        "X-GitHub-Api-Version": "2026-03-10",
         "User-Agent": user_agent,
     }
     body = None

--- a/workflow-dispatch-and-wait/README.md
+++ b/workflow-dispatch-and-wait/README.md
@@ -1,0 +1,62 @@
+# Workflow Dispatch and Wait
+
+Dispatch another GitHub Actions workflow via `workflow_dispatch` and optionally
+wait for it to finish.
+
+This action is a Python implementation of the common `workflow-dispatch` /
+`workflow-dispatch-and-wait` pattern. It can:
+
+- trigger a workflow by name, filename, or workflow ID
+- target the current repo or another repo
+- optionally wait for the triggered run to complete
+- optionally print or export the triggered run logs
+- optionally resolve and print the remote workflow run URL
+
+## Inputs
+
+- `workflow` (required): workflow name, filename, or ID to dispatch.
+- `token` (required): token with permission to dispatch workflows.
+- `inputs` (optional): JSON object string of workflow inputs.
+- `ref` (optional): branch, tag, or SHA to dispatch against.
+- `repo` (optional): target repository as `owner/name`.
+- `run-name` (optional): exact run name used to identify the triggered run.
+- `display-workflow-run-url` (optional): `true` or `false`.
+- `display-workflow-run-url-interval` (optional): poll interval like `30s`, `1m`, `1h`.
+- `display-workflow-run-url-timeout` (optional): timeout like `10m`.
+- `wait-for-completion` (optional): `true` or `false`.
+- `wait-for-completion-timeout` (optional): timeout like `1h`.
+- `wait-for-completion-interval` (optional): poll interval like `1m`.
+- `workflow-logs` (optional): `ignore`, `print`, `output`, or `json-output`.
+
+## Outputs
+
+- `workflow-conclusion`: remote workflow conclusion.
+- `workflow-id`: remote workflow run ID.
+- `workflow-url`: remote workflow run URL.
+- `workflow-logs`: remote workflow logs when `workflow-logs` is `output` or `json-output`.
+
+## Example
+
+```yaml
+- name: Trigger release workflow and wait
+  id: dispatch
+  uses: SolaceDev/solace-public-workflows/workflow-dispatch-and-wait@main
+  with:
+    workflow: release.yml
+    token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+    ref: main
+    inputs: >-
+      {
+        "version": "1.2.3"
+      }
+
+- name: Print remote conclusion
+  if: always()
+  run: echo "Conclusion: ${{ steps.dispatch.outputs.workflow-conclusion }}"
+```
+
+## Notes
+
+- `workflow_dispatch` must be enabled on the target workflow.
+- GitHub may take a short time before the dispatched run appears in workflow run listings.
+- If you use `run-name`, make it unique enough to identify the expected run.

--- a/workflow-dispatch-and-wait/README.md
+++ b/workflow-dispatch-and-wait/README.md
@@ -3,14 +3,16 @@
 Dispatch another GitHub Actions workflow via `workflow_dispatch` and optionally
 wait for it to finish.
 
-This action is a Python implementation of the common `workflow-dispatch` /
-`workflow-dispatch-and-wait` pattern. It can:
+This action uses the GitHub API `return_run_details` parameter (API version
+`2026-03-10`) to get the workflow run ID and URL directly from the dispatch
+response, eliminating the need to poll for run discovery.
+
+It can:
 
 - trigger a workflow by name, filename, or workflow ID
 - target the current repo or another repo
 - optionally wait for the triggered run to complete
 - optionally print or export the triggered run logs
-- optionally resolve and print the remote workflow run URL
 
 ## Inputs
 
@@ -19,10 +21,6 @@ This action is a Python implementation of the common `workflow-dispatch` /
 - `inputs` (optional): JSON object string of workflow inputs.
 - `ref` (optional): branch, tag, or SHA to dispatch against.
 - `repo` (optional): target repository as `owner/name`.
-- `run-name` (optional): exact run name used to identify the triggered run.
-- `display-workflow-run-url` (optional): `true` or `false`.
-- `display-workflow-run-url-interval` (optional): poll interval like `30s`, `1m`, `1h`.
-- `display-workflow-run-url-timeout` (optional): timeout like `10m`.
 - `wait-for-completion` (optional): `true` or `false`.
 - `wait-for-completion-timeout` (optional): timeout like `1h`.
 - `wait-for-completion-interval` (optional): poll interval like `1m`.
@@ -58,5 +56,4 @@ This action is a Python implementation of the common `workflow-dispatch` /
 ## Notes
 
 - `workflow_dispatch` must be enabled on the target workflow.
-- GitHub may take a short time before the dispatched run appears in workflow run listings.
-- If you use `run-name`, make it unique enough to identify the expected run.
+- Requires GitHub API version `2026-03-10` or later (handled automatically).

--- a/workflow-dispatch-and-wait/action.yml
+++ b/workflow-dispatch-and-wait/action.yml
@@ -21,22 +21,6 @@ inputs:
     description: "Target repository as owner/name; defaults to the current repository"
     required: false
     default: ""
-  run-name:
-    description: "Optional exact run name used to identify the triggered run"
-    required: false
-    default: ""
-  display-workflow-run-url:
-    description: "Whether to poll for and print the triggered workflow run URL"
-    required: false
-    default: "false"
-  display-workflow-run-url-interval:
-    description: "Polling interval while waiting for the workflow run URL"
-    required: false
-    default: "1m"
-  display-workflow-run-url-timeout:
-    description: "Timeout while waiting for the workflow run URL"
-    required: false
-    default: "10m"
   wait-for-completion:
     description: "Whether to wait for the triggered workflow to complete"
     required: false
@@ -80,10 +64,6 @@ runs:
         ACTION_INPUTS_JSON: ${{ inputs.inputs }}
         ACTION_REF: ${{ inputs.ref }}
         ACTION_REPO: ${{ inputs.repo }}
-        ACTION_RUN_NAME: ${{ inputs.run-name }}
-        ACTION_DISPLAY_WORKFLOW_RUN_URL: ${{ inputs.display-workflow-run-url }}
-        ACTION_DISPLAY_WORKFLOW_RUN_URL_INTERVAL: ${{ inputs.display-workflow-run-url-interval }}
-        ACTION_DISPLAY_WORKFLOW_RUN_URL_TIMEOUT: ${{ inputs.display-workflow-run-url-timeout }}
         ACTION_WAIT_FOR_COMPLETION: ${{ inputs.wait-for-completion }}
         ACTION_WAIT_FOR_COMPLETION_TIMEOUT: ${{ inputs.wait-for-completion-timeout }}
         ACTION_WAIT_FOR_COMPLETION_INTERVAL: ${{ inputs.wait-for-completion-interval }}

--- a/workflow-dispatch-and-wait/action.yml
+++ b/workflow-dispatch-and-wait/action.yml
@@ -1,0 +1,95 @@
+name: "Workflow Dispatch and Wait"
+description: "Trigger and optionally wait for GitHub Actions workflow_dispatch runs"
+author: "Solace"
+
+inputs:
+  workflow:
+    description: "Name, filename, or ID of the workflow to run"
+    required: true
+  token:
+    description: "GitHub token with permission to dispatch workflows"
+    required: true
+  inputs:
+    description: "Workflow inputs as a JSON object string"
+    required: false
+    default: ""
+  ref:
+    description: "Ref to dispatch the workflow on; defaults to the current workflow ref"
+    required: false
+    default: ""
+  repo:
+    description: "Target repository as owner/name; defaults to the current repository"
+    required: false
+    default: ""
+  run-name:
+    description: "Optional exact run name used to identify the triggered run"
+    required: false
+    default: ""
+  display-workflow-run-url:
+    description: "Whether to poll for and print the triggered workflow run URL"
+    required: false
+    default: "false"
+  display-workflow-run-url-interval:
+    description: "Polling interval while waiting for the workflow run URL"
+    required: false
+    default: "1m"
+  display-workflow-run-url-timeout:
+    description: "Timeout while waiting for the workflow run URL"
+    required: false
+    default: "10m"
+  wait-for-completion:
+    description: "Whether to wait for the triggered workflow to complete"
+    required: false
+    default: "true"
+  wait-for-completion-timeout:
+    description: "Maximum time to wait for workflow completion"
+    required: false
+    default: "1h"
+  wait-for-completion-interval:
+    description: "Polling interval while waiting for workflow completion"
+    required: false
+    default: "1m"
+  workflow-logs:
+    description: "How to handle remote workflow logs: ignore, print, output, or json-output"
+    required: false
+    default: "ignore"
+
+outputs:
+  workflow-conclusion:
+    description: "Conclusion of the triggered workflow"
+    value: ${{ steps.dispatch.outputs.workflow-conclusion }}
+  workflow-id:
+    description: "ID of the triggered workflow run"
+    value: ${{ steps.dispatch.outputs.workflow-id }}
+  workflow-url:
+    description: "URL of the triggered workflow run"
+    value: ${{ steps.dispatch.outputs.workflow-url }}
+  workflow-logs:
+    description: "Logs of the triggered workflow when workflow-logs is output or json-output"
+    value: ${{ steps.dispatch.outputs.workflow-logs }}
+
+runs:
+  using: composite
+  steps:
+    - name: Dispatch workflow and optionally wait
+      id: dispatch
+      shell: bash
+      env:
+        ACTION_WORKFLOW: ${{ inputs.workflow }}
+        ACTION_TOKEN: ${{ inputs.token }}
+        ACTION_INPUTS_JSON: ${{ inputs.inputs }}
+        ACTION_REF: ${{ inputs.ref }}
+        ACTION_REPO: ${{ inputs.repo }}
+        ACTION_RUN_NAME: ${{ inputs.run-name }}
+        ACTION_DISPLAY_WORKFLOW_RUN_URL: ${{ inputs.display-workflow-run-url }}
+        ACTION_DISPLAY_WORKFLOW_RUN_URL_INTERVAL: ${{ inputs.display-workflow-run-url-interval }}
+        ACTION_DISPLAY_WORKFLOW_RUN_URL_TIMEOUT: ${{ inputs.display-workflow-run-url-timeout }}
+        ACTION_WAIT_FOR_COMPLETION: ${{ inputs.wait-for-completion }}
+        ACTION_WAIT_FOR_COMPLETION_TIMEOUT: ${{ inputs.wait-for-completion-timeout }}
+        ACTION_WAIT_FOR_COMPLETION_INTERVAL: ${{ inputs.wait-for-completion-interval }}
+        ACTION_WORKFLOW_LOGS: ${{ inputs.workflow-logs }}
+      run: python3 "${{ github.action_path }}/scripts/run.py"
+
+branding:
+  color: purple
+  icon: send

--- a/workflow-dispatch-and-wait/scripts/run.py
+++ b/workflow-dispatch-and-wait/scripts/run.py
@@ -9,7 +9,6 @@ import re
 import sys
 import time
 import urllib.error
-import urllib.parse
 import urllib.request
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -139,25 +138,6 @@ def format_logs_as_json_output(logs_by_job: dict[str, str]) -> str:
     return json.dumps(result)
 
 
-def select_workflow_run(runs: list[dict[str, Any]], run_name: str) -> dict[str, Any]:
-    filtered = runs
-    if run_name:
-        filtered = [run for run in runs if str(run.get("name", "")) == run_name]
-
-    if not filtered:
-        raise RuntimeError("Run not found")
-
-    if len(filtered) > 1:
-        print(f"::warning::Found {len(filtered)} workflow runs. Using the latest one.")
-        debug("Filtered workflow runs", filtered)
-
-    return filtered[0]
-
-
-def now_utc_iso_no_millis() -> str:
-    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
-
-
 def download_text(url: str, token: str, user_agent: str) -> str:
     request = urllib.request.Request(
         url,
@@ -165,7 +145,7 @@ def download_text(url: str, token: str, user_agent: str) -> str:
         headers={
             "Authorization": f"Bearer {token}",
             "Accept": "application/vnd.github+json",
-            "X-GitHub-Api-Version": "2022-11-28",
+            "X-GitHub-Api-Version": "2026-03-10",
             "User-Agent": user_agent,
         },
     )
@@ -185,10 +165,6 @@ class Args:
     owner: str
     repo: str
     inputs: dict[str, Any]
-    run_name: str
-    display_workflow_url: bool
-    display_workflow_url_interval_ms: int
-    display_workflow_url_timeout_ms: int
     wait_for_completion: bool
     wait_for_completion_timeout_ms: int
     wait_for_completion_interval_ms: int
@@ -200,7 +176,6 @@ def get_args() -> Args:
     workflow_ref = os.getenv("ACTION_WORKFLOW", "").strip()
     ref = os.getenv("ACTION_REF", "").strip() or os.getenv("GITHUB_REF", "").strip()
     repo_input = os.getenv("ACTION_REPO", "").strip() or os.getenv("GITHUB_REPOSITORY", "").strip()
-    run_name = os.getenv("ACTION_RUN_NAME", "").strip()
 
     if not token:
         raise ValueError("Missing required input 'token'")
@@ -220,14 +195,6 @@ def get_args() -> Args:
         owner=owner,
         repo=repo,
         inputs=parse_inputs_json(os.getenv("ACTION_INPUTS_JSON", "")),
-        run_name=run_name,
-        display_workflow_url=parse_bool(os.getenv("ACTION_DISPLAY_WORKFLOW_RUN_URL", ""), default=True),
-        display_workflow_url_interval_ms=to_milliseconds(
-            os.getenv("ACTION_DISPLAY_WORKFLOW_RUN_URL_INTERVAL", "1m")
-        ),
-        display_workflow_url_timeout_ms=to_milliseconds(
-            os.getenv("ACTION_DISPLAY_WORKFLOW_RUN_URL_TIMEOUT", "10m")
-        ),
         wait_for_completion=parse_bool(os.getenv("ACTION_WAIT_FOR_COMPLETION", ""), default=True),
         wait_for_completion_timeout_ms=to_milliseconds(
             os.getenv("ACTION_WAIT_FOR_COMPLETION_TIMEOUT", "1h")
@@ -239,25 +206,44 @@ def get_args() -> Args:
     )
 
 
+@dataclass
+class DispatchResult:
+    run_id: int
+    run_url: str
+    html_url: str
+
+
 class WorkflowHandler:
     def __init__(self, args: Args) -> None:
         self.args = args
         self.api_base = os.getenv("GITHUB_API_URL", "https://api.github.com").rstrip("/")
         self.user_agent = "solace-public-workflows/workflow-dispatch-and-wait"
         self.workflow_id: int | str | None = None
-        self.workflow_run_id: int | None = None
-        self.trigger_date: str = ""
 
-    def trigger_workflow(self) -> None:
+    def dispatch_workflow(self) -> DispatchResult:
+        """Dispatch the workflow and return run details from the API response."""
         workflow_id = self.get_workflow_id()
-        self.trigger_date = now_utc_iso_no_millis()
         url = (
             f"{self.api_base}/repos/{self.args.owner}/{self.args.repo}/actions/workflows/"
             f"{workflow_id}/dispatches"
         )
-        payload = {"ref": self.args.ref, "inputs": self.args.inputs}
-        github_api("POST", url, self.args.token, payload, user_agent=self.user_agent)
-        debug("Workflow dispatch payload", payload)
+        payload = {
+            "ref": self.args.ref,
+            "inputs": self.args.inputs,
+            "return_run_details": True,
+        }
+        response = github_api("POST", url, self.args.token, payload, user_agent=self.user_agent)
+        debug("Workflow dispatch response", response)
+
+        run_id = int(response.get("workflow_run_id", 0))
+        if not run_id:
+            raise RuntimeError("Dispatch succeeded but no workflow_run_id in response")
+
+        return DispatchResult(
+            run_id=run_id,
+            run_url=str(response.get("run_url", "")),
+            html_url=str(response.get("html_url", "")),
+        )
 
     def get_workflow_id(self) -> int | str:
         if self.workflow_id is not None:
@@ -283,47 +269,16 @@ class WorkflowHandler:
             f"Unable to find workflow '{self.args.workflow_ref}' in {self.args.owner}/{self.args.repo}"
         )
 
-    def list_workflow_runs(self) -> list[dict[str, Any]]:
-        workflow_id = self.get_workflow_id()
-        params = urllib.parse.urlencode(
-            {
-                "event": "workflow_dispatch",
-                "created": f">={self.trigger_date}",
-                "per_page": 100,
-            }
-        )
-        url = (
-            f"{self.api_base}/repos/{self.args.owner}/{self.args.repo}/actions/workflows/"
-            f"{workflow_id}/runs?{params}"
-        )
-        payload = github_api("GET", url, self.args.token, user_agent=self.user_agent)
-        runs = payload.get("workflow_runs", []) if isinstance(payload, dict) else []
-        debug("List workflow runs", runs)
-        return runs
-
-    def get_workflow_run_id(self) -> int:
-        if self.workflow_run_id is not None:
-            return self.workflow_run_id
-
-        selected = select_workflow_run(self.list_workflow_runs(), self.args.run_name)
-        self.workflow_run_id = int(selected["id"])
-        return self.workflow_run_id
-
-    def get_workflow_run_status(self) -> dict[str, Any]:
-        run_id = self.get_workflow_run_id()
+    def get_workflow_run_status(self, run_id: int) -> dict[str, Any]:
         url = f"{self.api_base}/repos/{self.args.owner}/{self.args.repo}/actions/runs/{run_id}"
         payload = github_api("GET", url, self.args.token, user_agent=self.user_agent)
         debug("Workflow run status", payload)
 
-        status = str(payload.get("status") or "queued")
-        conclusion = str(payload.get("conclusion") or "neutral")
-        html_url = str(payload.get("html_url") or "")
-
         return {
             "id": run_id,
-            "url": html_url,
-            "status": status,
-            "conclusion": conclusion,
+            "url": str(payload.get("html_url") or ""),
+            "status": str(payload.get("status") or "queued"),
+            "conclusion": str(payload.get("conclusion") or "neutral"),
         }
 
     def list_jobs_for_workflow_run(self, run_id: int) -> list[dict[str, Any]]:
@@ -341,27 +296,9 @@ class WorkflowHandler:
         return download_text(url, self.args.token, self.user_agent)
 
 
-def get_follow_url(
-    workflow_handler: WorkflowHandler,
-    interval_ms: int,
-    timeout_ms: int,
-) -> str:
-    start = time.monotonic()
-    while not is_timed_out(start, timeout_ms):
-        sleep_ms(interval_ms)
-        try:
-            result = workflow_handler.get_workflow_run_status()
-            if result["id"]:
-                write_output("workflow-id", str(result["id"]))
-            if result["url"]:
-                return str(result["url"])
-        except Exception as exc:
-            debug(f"Failed to get workflow URL: {exc}")
-    return ""
-
-
 def wait_for_completion_or_timeout(
     workflow_handler: WorkflowHandler,
+    run_id: int,
     interval_ms: int,
     timeout_ms: int,
 ) -> tuple[dict[str, Any] | None, float]:
@@ -371,12 +308,7 @@ def wait_for_completion_or_timeout(
     while not is_timed_out(start, timeout_ms):
         sleep_ms(interval_ms)
         try:
-            result = workflow_handler.get_workflow_run_status()
-            if result["id"]:
-                write_output("workflow-id", str(result["id"]))
-            if result["url"]:
-                write_output("workflow-url", str(result["url"]))
-
+            result = workflow_handler.get_workflow_run_status(run_id)
             status = str(result["status"])
             debug(
                 f"Workflow is running for {format_duration(int((time.monotonic() - start) * 1000))}. "
@@ -390,12 +322,11 @@ def wait_for_completion_or_timeout(
     return result, start
 
 
-def handle_logs(args: Args, workflow_handler: WorkflowHandler) -> None:
+def handle_logs(args: Args, workflow_handler: WorkflowHandler, run_id: int) -> None:
     if args.workflow_logs_mode not in {"print", "output", "json-output"}:
         return
 
     try:
-        run_id = workflow_handler.get_workflow_run_id()
         jobs = workflow_handler.list_jobs_for_workflow_run(run_id)
     except Exception as exc:
         print(f"::error::Failed to list jobs for triggered workflow. Cause: {exc}")
@@ -453,20 +384,14 @@ def main() -> int:
         args = get_args()
         workflow_handler = WorkflowHandler(args)
 
-        workflow_handler.trigger_workflow()
-        print("Workflow triggered 🚀")
+        dispatched = workflow_handler.dispatch_workflow()
+        run_id = dispatched.run_id
+        html_url = dispatched.html_url
 
-        if args.display_workflow_url:
-            url = get_follow_url(
-                workflow_handler,
-                args.display_workflow_url_interval_ms,
-                args.display_workflow_url_timeout_ms,
-            )
-            if url:
-                print(f"You can follow the running workflow here: {url}")
-                write_output("workflow-url", url)
-            else:
-                print("Workflow URL could not be resolved before timeout.")
+        write_output("workflow-id", str(run_id))
+        write_output("workflow-url", html_url)
+
+        print(f"Workflow triggered: {html_url}")
 
         if not args.wait_for_completion:
             return 0
@@ -474,15 +399,12 @@ def main() -> int:
         print("Waiting for workflow completion")
         result, start = wait_for_completion_or_timeout(
             workflow_handler,
+            run_id,
             args.wait_for_completion_interval_ms,
             args.wait_for_completion_timeout_ms,
         )
 
-        handle_logs(args, workflow_handler)
-
-        if result:
-            write_output("workflow-id", str(result["id"]))
-            write_output("workflow-url", str(result["url"]))
+        handle_logs(args, workflow_handler, run_id)
 
         return compute_conclusion(start, args.wait_for_completion_timeout_ms, result)
     except Exception as exc:

--- a/workflow-dispatch-and-wait/scripts/run.py
+++ b/workflow-dispatch-and-wait/scripts/run.py
@@ -1,0 +1,494 @@
+#!/usr/bin/env python3
+"""Dispatch a workflow_dispatch workflow and optionally wait for completion."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _bootstrap_common_module() -> None:
+    script_path = Path(__file__).resolve()
+    for parent in script_path.parents:
+        candidate = parent / "common" / "github_reporting.py"
+        if candidate.exists():
+            sys.path.insert(0, str(candidate.parent))
+            return
+
+
+_bootstrap_common_module()
+
+from github_reporting import github_api, write_output  # type: ignore  # noqa: E402
+
+
+WORKFLOW_RUN_STATUS_COMPLETED = "completed"
+FAILING_CONCLUSIONS = {"failure", "cancelled", "timed_out"}
+TIMESTAMPED_LOG_LINE = re.compile(r"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{7}Z)\s+(.*)")
+
+
+def debug(message: str, payload: Any | None = None) -> None:
+    if os.getenv("RUNNER_DEBUG") != "1":
+        return
+
+    if payload is None:
+        print(f"::debug::{message}")
+        return
+
+    try:
+        rendered = json.dumps(payload, indent=2, sort_keys=True)
+    except Exception:
+        rendered = str(payload)
+    print(f"::group::{message}")
+    print(f"::debug::{rendered}")
+    print("::endgroup::")
+
+
+def parse_bool(value: str, *, default: bool = False) -> bool:
+    if value is None:
+        return default
+    stripped = value.strip()
+    if not stripped:
+        return default
+    return stripped.lower() == "true"
+
+
+def to_milliseconds(value: str) -> int:
+    stripped = (value or "").strip()
+    if len(stripped) < 2:
+        raise ValueError(f"Invalid duration '{value}'")
+
+    unit = stripped[-1].lower()
+    multiplier = {"s": 1000, "m": 60_000, "h": 3_600_000}.get(unit)
+    if multiplier is None:
+        raise ValueError(f"Unknown time unit '{unit}' in duration '{value}'")
+
+    try:
+        amount = float(stripped[:-1])
+    except ValueError as exc:
+        raise ValueError(f"Invalid duration '{value}'") from exc
+
+    return int(amount * multiplier)
+
+
+def parse_inputs_json(inputs_json: str) -> dict[str, Any]:
+    if not inputs_json.strip():
+        return {}
+
+    try:
+        parsed = json.loads(inputs_json)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Failed to parse 'inputs' parameter as JSON: {exc}") from exc
+
+    if not isinstance(parsed, dict):
+        raise ValueError("'inputs' parameter must decode to a JSON object")
+    return parsed
+
+
+def format_duration(duration_ms: int) -> str:
+    total_seconds = max(int(duration_ms / 1000), 0)
+    hours = total_seconds // 3600
+    minutes = (total_seconds % 3600) // 60
+    seconds = total_seconds % 60
+    return f"{hours:02d}h {minutes:02d}m {seconds:02d}s"
+
+
+def is_timed_out(start_monotonic: float, timeout_ms: int) -> bool:
+    return (time.monotonic() - start_monotonic) * 1000 >= timeout_ms
+
+
+def sleep_ms(duration_ms: int) -> None:
+    time.sleep(max(duration_ms, 0) / 1000)
+
+
+def escape_imported_logs(text: str) -> str:
+    escaped = re.sub(r"^", "| ", text, flags=re.MULTILINE)
+    return re.sub(r"##\[([^\]]+)\]", r"##<\1>", escaped)
+
+
+def format_logs_as_output(logs_by_job: dict[str, str]) -> str:
+    lines: list[str] = []
+    for job_name, logs in logs_by_job.items():
+        for line in logs.splitlines():
+            lines.append(f"{job_name} | {line}")
+    return "\n".join(lines)
+
+
+def format_logs_as_json_output(logs_by_job: dict[str, str]) -> str:
+    result: dict[str, list[dict[str, str]]] = {}
+    for job_name, logs in logs_by_job.items():
+        entries: list[dict[str, str]] = []
+        for line in logs.splitlines():
+            if not line:
+                continue
+            match = TIMESTAMPED_LOG_LINE.match(line)
+            if match:
+                entries.append({"datetime": match.group(1), "message": match.group(2)})
+            else:
+                entries.append({"datetime": "", "message": line})
+        result[job_name] = entries
+    return json.dumps(result)
+
+
+def select_workflow_run(runs: list[dict[str, Any]], run_name: str) -> dict[str, Any]:
+    filtered = runs
+    if run_name:
+        filtered = [run for run in runs if str(run.get("name", "")) == run_name]
+
+    if not filtered:
+        raise RuntimeError("Run not found")
+
+    if len(filtered) > 1:
+        print(f"::warning::Found {len(filtered)} workflow runs. Using the latest one.")
+        debug("Filtered workflow runs", filtered)
+
+    return filtered[0]
+
+
+def now_utc_iso_no_millis() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def download_text(url: str, token: str, user_agent: str) -> str:
+    request = urllib.request.Request(
+        url,
+        method="GET",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": user_agent,
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            return response.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as err:
+        detail = err.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"GitHub API GET {url} failed: {err.code} {detail}") from err
+
+
+@dataclass
+class Args:
+    token: str
+    workflow_ref: str
+    ref: str
+    owner: str
+    repo: str
+    inputs: dict[str, Any]
+    run_name: str
+    display_workflow_url: bool
+    display_workflow_url_interval_ms: int
+    display_workflow_url_timeout_ms: int
+    wait_for_completion: bool
+    wait_for_completion_timeout_ms: int
+    wait_for_completion_interval_ms: int
+    workflow_logs_mode: str
+
+
+def get_args() -> Args:
+    token = os.getenv("ACTION_TOKEN", "").strip()
+    workflow_ref = os.getenv("ACTION_WORKFLOW", "").strip()
+    ref = os.getenv("ACTION_REF", "").strip() or os.getenv("GITHUB_REF", "").strip()
+    repo_input = os.getenv("ACTION_REPO", "").strip() or os.getenv("GITHUB_REPOSITORY", "").strip()
+    run_name = os.getenv("ACTION_RUN_NAME", "").strip()
+
+    if not token:
+        raise ValueError("Missing required input 'token'")
+    if not workflow_ref:
+        raise ValueError("Missing required input 'workflow'")
+    if not ref:
+        raise ValueError("Missing workflow ref; set 'ref' input or ensure GITHUB_REF is present")
+    if "/" not in repo_input:
+        raise ValueError(f"Invalid repo value '{repo_input}'. Expected owner/name")
+
+    owner, repo = repo_input.split("/", 1)
+
+    return Args(
+        token=token,
+        workflow_ref=workflow_ref,
+        ref=ref,
+        owner=owner,
+        repo=repo,
+        inputs=parse_inputs_json(os.getenv("ACTION_INPUTS_JSON", "")),
+        run_name=run_name,
+        display_workflow_url=parse_bool(os.getenv("ACTION_DISPLAY_WORKFLOW_RUN_URL", ""), default=True),
+        display_workflow_url_interval_ms=to_milliseconds(
+            os.getenv("ACTION_DISPLAY_WORKFLOW_RUN_URL_INTERVAL", "1m")
+        ),
+        display_workflow_url_timeout_ms=to_milliseconds(
+            os.getenv("ACTION_DISPLAY_WORKFLOW_RUN_URL_TIMEOUT", "10m")
+        ),
+        wait_for_completion=parse_bool(os.getenv("ACTION_WAIT_FOR_COMPLETION", ""), default=True),
+        wait_for_completion_timeout_ms=to_milliseconds(
+            os.getenv("ACTION_WAIT_FOR_COMPLETION_TIMEOUT", "1h")
+        ),
+        wait_for_completion_interval_ms=to_milliseconds(
+            os.getenv("ACTION_WAIT_FOR_COMPLETION_INTERVAL", "1m")
+        ),
+        workflow_logs_mode=os.getenv("ACTION_WORKFLOW_LOGS", "ignore").strip() or "ignore",
+    )
+
+
+class WorkflowHandler:
+    def __init__(self, args: Args) -> None:
+        self.args = args
+        self.api_base = os.getenv("GITHUB_API_URL", "https://api.github.com").rstrip("/")
+        self.user_agent = "solace-public-workflows/workflow-dispatch-and-wait"
+        self.workflow_id: int | str | None = None
+        self.workflow_run_id: int | None = None
+        self.trigger_date: str = ""
+
+    def trigger_workflow(self) -> None:
+        workflow_id = self.get_workflow_id()
+        self.trigger_date = now_utc_iso_no_millis()
+        url = (
+            f"{self.api_base}/repos/{self.args.owner}/{self.args.repo}/actions/workflows/"
+            f"{workflow_id}/dispatches"
+        )
+        payload = {"ref": self.args.ref, "inputs": self.args.inputs}
+        github_api("POST", url, self.args.token, payload, user_agent=self.user_agent)
+        debug("Workflow dispatch payload", payload)
+
+    def get_workflow_id(self) -> int | str:
+        if self.workflow_id is not None:
+            return self.workflow_id
+
+        if re.fullmatch(r".+\.ya?ml", self.args.workflow_ref):
+            self.workflow_id = self.args.workflow_ref
+            return self.workflow_id
+
+        url = f"{self.api_base}/repos/{self.args.owner}/{self.args.repo}/actions/workflows?per_page=100"
+        payload = github_api("GET", url, self.args.token, user_agent=self.user_agent)
+        workflows = payload.get("workflows", []) if isinstance(payload, dict) else []
+        debug("List workflows", workflows)
+
+        for workflow in workflows:
+            workflow_name = str(workflow.get("name", ""))
+            workflow_id = str(workflow.get("id", ""))
+            if workflow_name == self.args.workflow_ref or workflow_id == self.args.workflow_ref:
+                self.workflow_id = int(workflow["id"])
+                return self.workflow_id
+
+        raise RuntimeError(
+            f"Unable to find workflow '{self.args.workflow_ref}' in {self.args.owner}/{self.args.repo}"
+        )
+
+    def list_workflow_runs(self) -> list[dict[str, Any]]:
+        workflow_id = self.get_workflow_id()
+        params = urllib.parse.urlencode(
+            {
+                "event": "workflow_dispatch",
+                "created": f">={self.trigger_date}",
+                "per_page": 100,
+            }
+        )
+        url = (
+            f"{self.api_base}/repos/{self.args.owner}/{self.args.repo}/actions/workflows/"
+            f"{workflow_id}/runs?{params}"
+        )
+        payload = github_api("GET", url, self.args.token, user_agent=self.user_agent)
+        runs = payload.get("workflow_runs", []) if isinstance(payload, dict) else []
+        debug("List workflow runs", runs)
+        return runs
+
+    def get_workflow_run_id(self) -> int:
+        if self.workflow_run_id is not None:
+            return self.workflow_run_id
+
+        selected = select_workflow_run(self.list_workflow_runs(), self.args.run_name)
+        self.workflow_run_id = int(selected["id"])
+        return self.workflow_run_id
+
+    def get_workflow_run_status(self) -> dict[str, Any]:
+        run_id = self.get_workflow_run_id()
+        url = f"{self.api_base}/repos/{self.args.owner}/{self.args.repo}/actions/runs/{run_id}"
+        payload = github_api("GET", url, self.args.token, user_agent=self.user_agent)
+        debug("Workflow run status", payload)
+
+        status = str(payload.get("status") or "queued")
+        conclusion = str(payload.get("conclusion") or "neutral")
+        html_url = str(payload.get("html_url") or "")
+
+        return {
+            "id": run_id,
+            "url": html_url,
+            "status": status,
+            "conclusion": conclusion,
+        }
+
+    def list_jobs_for_workflow_run(self, run_id: int) -> list[dict[str, Any]]:
+        url = (
+            f"{self.api_base}/repos/{self.args.owner}/{self.args.repo}/actions/runs/{run_id}/jobs"
+            "?per_page=100"
+        )
+        payload = github_api("GET", url, self.args.token, user_agent=self.user_agent)
+        jobs = payload.get("jobs", []) if isinstance(payload, dict) else []
+        debug("Workflow run jobs", jobs)
+        return jobs
+
+    def download_job_logs(self, job_id: int) -> str:
+        url = f"{self.api_base}/repos/{self.args.owner}/{self.args.repo}/actions/jobs/{job_id}/logs"
+        return download_text(url, self.args.token, self.user_agent)
+
+
+def get_follow_url(
+    workflow_handler: WorkflowHandler,
+    interval_ms: int,
+    timeout_ms: int,
+) -> str:
+    start = time.monotonic()
+    while not is_timed_out(start, timeout_ms):
+        sleep_ms(interval_ms)
+        try:
+            result = workflow_handler.get_workflow_run_status()
+            if result["id"]:
+                write_output("workflow-id", str(result["id"]))
+            if result["url"]:
+                return str(result["url"])
+        except Exception as exc:
+            debug(f"Failed to get workflow URL: {exc}")
+    return ""
+
+
+def wait_for_completion_or_timeout(
+    workflow_handler: WorkflowHandler,
+    interval_ms: int,
+    timeout_ms: int,
+) -> tuple[dict[str, Any] | None, float]:
+    start = time.monotonic()
+    result: dict[str, Any] | None = None
+
+    while not is_timed_out(start, timeout_ms):
+        sleep_ms(interval_ms)
+        try:
+            result = workflow_handler.get_workflow_run_status()
+            if result["id"]:
+                write_output("workflow-id", str(result["id"]))
+            if result["url"]:
+                write_output("workflow-url", str(result["url"]))
+
+            status = str(result["status"])
+            debug(
+                f"Workflow is running for {format_duration(int((time.monotonic() - start) * 1000))}. "
+                f"Current status={status}"
+            )
+            if status == WORKFLOW_RUN_STATUS_COMPLETED:
+                return result, start
+        except Exception as exc:
+            print(f"::warning::Failed to get workflow status: {exc}")
+
+    return result, start
+
+
+def handle_logs(args: Args, workflow_handler: WorkflowHandler) -> None:
+    if args.workflow_logs_mode not in {"print", "output", "json-output"}:
+        return
+
+    try:
+        run_id = workflow_handler.get_workflow_run_id()
+        jobs = workflow_handler.list_jobs_for_workflow_run(run_id)
+    except Exception as exc:
+        print(f"::error::Failed to list jobs for triggered workflow. Cause: {exc}")
+        return
+
+    logs_by_job: dict[str, str] = {}
+    for job in jobs:
+        job_name = str(job.get("name") or f"job-{job.get('id')}")
+        job_id = int(job["id"])
+        try:
+            logs_by_job[job_name] = workflow_handler.download_job_logs(job_id)
+        except Exception as exc:
+            print(f"::warning::Failed to download logs for job '{job_name}'. Cause: {exc}")
+
+    if args.workflow_logs_mode == "print":
+        for job_name, logs in logs_by_job.items():
+            print(f"::group::Logs of job '{job_name}'")
+            print(escape_imported_logs(logs))
+            print("::endgroup::")
+        return
+
+    if args.workflow_logs_mode == "output":
+        write_output("workflow-logs", format_logs_as_output(logs_by_job))
+        return
+
+    if args.workflow_logs_mode == "json-output":
+        write_output("workflow-logs", format_logs_as_json_output(logs_by_job))
+
+
+def compute_conclusion(
+    start_monotonic: float,
+    timeout_ms: int,
+    result: dict[str, Any] | None,
+) -> int:
+    if is_timed_out(start_monotonic, timeout_ms):
+        print("Workflow wait timed out")
+        write_output("workflow-conclusion", "timed_out")
+        raise RuntimeError("Workflow run has failed due to timeout")
+
+    conclusion = str((result or {}).get("conclusion") or "neutral")
+    print(f"Workflow completed with conclusion={conclusion}")
+    write_output("workflow-conclusion", conclusion)
+
+    if conclusion == "failure":
+        raise RuntimeError("Workflow run has failed")
+    if conclusion == "cancelled":
+        raise RuntimeError("Workflow run was cancelled")
+    if conclusion == "timed_out":
+        raise RuntimeError("Workflow run has failed due to timeout")
+    return 0
+
+
+def main() -> int:
+    try:
+        args = get_args()
+        workflow_handler = WorkflowHandler(args)
+
+        workflow_handler.trigger_workflow()
+        print("Workflow triggered 🚀")
+
+        if args.display_workflow_url:
+            url = get_follow_url(
+                workflow_handler,
+                args.display_workflow_url_interval_ms,
+                args.display_workflow_url_timeout_ms,
+            )
+            if url:
+                print(f"You can follow the running workflow here: {url}")
+                write_output("workflow-url", url)
+            else:
+                print("Workflow URL could not be resolved before timeout.")
+
+        if not args.wait_for_completion:
+            return 0
+
+        print("Waiting for workflow completion")
+        result, start = wait_for_completion_or_timeout(
+            workflow_handler,
+            args.wait_for_completion_interval_ms,
+            args.wait_for_completion_timeout_ms,
+        )
+
+        handle_logs(args, workflow_handler)
+
+        if result:
+            write_output("workflow-id", str(result["id"]))
+            write_output("workflow-url", str(result["url"]))
+
+        return compute_conclusion(start, args.wait_for_completion_timeout_ms, result)
+    except Exception as exc:
+        print(f"::error::{exc}")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workflow-dispatch-and-wait/tests/test_run.py
+++ b/workflow-dispatch-and-wait/tests/test_run.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Unit tests for workflow-dispatch-and-wait helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "run.py"
+SPEC = importlib.util.spec_from_file_location("workflow_dispatch_and_wait_run", MODULE_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+class TestWorkflowDispatchAndWaitHelpers(unittest.TestCase):
+    def test_to_milliseconds_supports_seconds_minutes_and_hours(self) -> None:
+        self.assertEqual(MODULE.to_milliseconds("30s"), 30_000)
+        self.assertEqual(MODULE.to_milliseconds("1.5m"), 90_000)
+        self.assertEqual(MODULE.to_milliseconds("2h"), 7_200_000)
+
+    def test_parse_inputs_json_requires_object(self) -> None:
+        self.assertEqual(MODULE.parse_inputs_json(""), {})
+        self.assertEqual(MODULE.parse_inputs_json('{"name":"value"}'), {"name": "value"})
+
+        with self.assertRaises(ValueError):
+            MODULE.parse_inputs_json("[1,2,3]")
+
+        with self.assertRaises(ValueError):
+            MODULE.parse_inputs_json("{not-json}")
+
+    def test_select_workflow_run_filters_by_run_name(self) -> None:
+        runs = [
+            {"id": 3, "name": "other"},
+            {"id": 2, "name": "target"},
+        ]
+
+        selected = MODULE.select_workflow_run(runs, "target")
+        self.assertEqual(selected["id"], 2)
+
+    def test_format_logs_outputs(self) -> None:
+        logs_by_job = {
+            "build": (
+                "2026-03-09T12:34:56.1234567Z First line\n"
+                "2026-03-09T12:34:57.1234567Z Second line"
+            ),
+        }
+
+        output_logs = MODULE.format_logs_as_output(logs_by_job)
+        self.assertIn("build | 2026-03-09T12:34:56.1234567Z First line", output_logs)
+
+        json_logs = json.loads(MODULE.format_logs_as_json_output(logs_by_job))
+        self.assertEqual(
+            json_logs,
+            {
+                "build": [
+                    {"datetime": "2026-03-09T12:34:56.1234567Z", "message": "First line"},
+                    {"datetime": "2026-03-09T12:34:57.1234567Z", "message": "Second line"},
+                ]
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/workflow-dispatch-and-wait/tests/test_run.py
+++ b/workflow-dispatch-and-wait/tests/test_run.py
@@ -35,15 +35,6 @@ class TestWorkflowDispatchAndWaitHelpers(unittest.TestCase):
         with self.assertRaises(ValueError):
             MODULE.parse_inputs_json("{not-json}")
 
-    def test_select_workflow_run_filters_by_run_name(self) -> None:
-        runs = [
-            {"id": 3, "name": "other"},
-            {"id": 2, "name": "target"},
-        ]
-
-        selected = MODULE.select_workflow_run(runs, "target")
-        self.assertEqual(selected["id"], 2)
-
     def test_format_logs_outputs(self) -> None:
         logs_by_job = {
             "build": (
@@ -65,6 +56,18 @@ class TestWorkflowDispatchAndWaitHelpers(unittest.TestCase):
                 ]
             },
         )
+
+    def test_format_duration(self) -> None:
+        self.assertEqual(MODULE.format_duration(0), "00h 00m 00s")
+        self.assertEqual(MODULE.format_duration(61_000), "00h 01m 01s")
+        self.assertEqual(MODULE.format_duration(3_661_000), "01h 01m 01s")
+
+    def test_parse_bool(self) -> None:
+        self.assertFalse(MODULE.parse_bool(""))
+        self.assertFalse(MODULE.parse_bool("false"))
+        self.assertTrue(MODULE.parse_bool("true"))
+        self.assertTrue(MODULE.parse_bool("True"))
+        self.assertTrue(MODULE.parse_bool("  true  "))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds a new reusable GitHub Action that triggers a `workflow_dispatch` workflow in the current or a different repository and optionally waits for it to complete.

## What is the purpose of this change?

This change introduces a Python-based composite action that simplifies the common pattern of triggering remote workflows and monitoring their execution. The action provides:

- Workflow triggering by name, filename, or workflow ID
- Cross-repository workflow dispatch support
- Optional waiting for workflow completion with configurable timeouts
- Workflow URL resolution and display
- Remote workflow log retrieval (print, output, or JSON output formats)

## How is this accomplished?

The implementation consists of:

- **`action.yml`** - Composite action definition with 13 configurable inputs (workflow, token, ref, repo, inputs, run-name, polling intervals/timeouts, and log handling options) and 4 outputs (conclusion, ID, URL, logs)
- **`scripts/run.py`** - Core Python implementation (~494 lines) that:
  - Dispatches workflows via the GitHub API
  - Polls for workflow run appearance and completion
  - Downloads and formats job logs in multiple output formats
  - Handles timeouts and error states
- **`tests/test_run.py`** - Unit tests covering time parsing, input validation, run selection, and log formatting
- **`README.md`** - Documentation with usage examples and configuration reference

The action uses environment variables for input parameters and writes outputs to `$GITHUB_OUTPUT` for consumption by downstream steps.

