### PR TITLE
fix(DATAGO-132737): remove pip cache from hatch setup

### DIFF
--- a/.github/actions/hatch-lint-test/action.yml
+++ b/.github/actions/hatch-lint-test/action.yml
@@ -55,21 +55,21 @@ runs:
         hatch test --python ${{ inputs.max-python-version }}  --cover --parallel --junitxml=junit-${{ inputs.max-python-version }}.xml
 
     - name: Status Check - Unit Tests on default python version
-      uses: mikepenz/action-junit-report@v5
+      uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # v6.4.0
       if: hashFiles('junit-default.xml') != ''
       with:
         check_name: Unit Tests on default python version
         report_paths: junit-default.xml
 
     - name: Status Check - Unit Tests on Python ${{ inputs.min-python-version }}
-      uses: mikepenz/action-junit-report@v5
+      uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # v6.4.0
       if: hashFiles('junit-${{ inputs.min-python-version }}.xml') != ''
       with:
         check_name: Unit Tests on Python ${{ inputs.min-python-version }}
         report_paths: junit-${{ inputs.min-python-version }}.xml
 
     - name: Status Check - Unit Tests on Python ${{ inputs.max-python-version }}
-      uses: mikepenz/action-junit-report@v5
+      uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # v6.4.0
       if: hashFiles('junit-${{ inputs.max-python-version }}.xml') != ''
       with:
         check_name: Unit Tests on Python ${{ inputs.max-python-version }}
@@ -95,7 +95,7 @@ runs:
       env:
         MIN_PYTHON_VERSION_FILE: ${{ format('junit-{0}.xml', inputs.min-python-version) }}
         MAX_PYTHON_VERSION_FILE: ${{ format('junit-{0}.xml', inputs.max-python-version) }}
-      uses: xportation/junit-coverage-report@main
+      uses: xportation/junit-coverage-report@700eca2594fa883c7811f12f74be5ff74f04b8ca
       with:
         junit-path: ${{ hashFiles('junit-default.xml') != '' && 'junit-default.xml' || hashFiles(env.MIN_PYTHON_VERSION_FILE) != '' && env.MIN_PYTHON_VERSION_FILE || hashFiles(env.MAX_PYTHON_VERSION_FILE) != '' && env.MAX_PYTHON_VERSION_FILE }}
         coverage-path: coverage.xml

--- a/.github/actions/hatch-setup/action.yml
+++ b/.github/actions/hatch-setup/action.yml
@@ -31,7 +31,7 @@ runs:
       shell: bash
 
     - name: Install Hatch
-      uses: pypa/hatch@install
+      uses: pypa/hatch@a3c83ab3d481fbc2dc91dd0088628817488dd1d5
 
     - name: Test Matrix Present
       id: test-matrix-present
@@ -59,7 +59,7 @@ runs:
         echo "matrix-present=$MATRIX_PRESENT" >> $GITHUB_OUTPUT
 
     - name: Restore Hatch Directory
-      uses: actions/cache@v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       id: cache
       with:
         path: |
@@ -70,22 +70,18 @@ runs:
     - name: Install Python Versions for Hatch Test Matrix
       id: setup-python
       if: steps.test-matrix-present.outputs.matrix-present == 'true'
-      uses: actions/setup-python@v5.5.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: |
           ${{ inputs.min-python-version }}
           ${{ inputs.max-python-version }}
-        cache: "pip"
-        cache-dependency-path: "pyproject.toml"
 
     - name: Install Python Version from pyproject.toml
       id: setup-python-default
       if: steps.test-matrix-present.outputs.matrix-present == 'false'
-      uses: actions/setup-python@v5.5.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version-file: "pyproject.toml"
-        cache: "pip"
-        cache-dependency-path: "pyproject.toml"
 
     - name: Export Python Path For Hatch
       shell: bash


### PR DESCRIPTION
## Summary

Removes pip cache configuration from the hatch setup action and pins all third-party GitHub Actions to full commit SHAs for improved security and reproducibility.

It was causing this error post action because of the new python version on the runners
<img width="917" height="290" alt="Screenshot 2026-04-21 at 9 29 46 AM" src="https://github.com/user-attachments/assets/af33eee3-650c-405b-9520-6bd15cd0eb32" />


### What is the purpose of this change?

Remove the `pip` cache from the `setup-python` steps in the hatch setup action. Hatch manages its own virtual environments and dependencies, so caching pip separately is unnecessary and can cause issues.

### How is this accomplished?

- Remove `cache: "pip"` and `cache-dependency-path: "pyproject.toml"` from both `setup-python` steps in `hatch-setup/action.yml`
- Pin all third-party action references to full commit SHAs instead of mutable tags:
  - `mikepenz/action-junit-report` → `bccf2e31636835cf0874589931c4116687171386` (v6.4.0)
  - `xportation/junit-coverage-report` → `700eca2594fa883c7811f12f74be5ff74f04b8ca`
  - `pypa/hatch` → `a3c83ab3d481fbc2dc91dd0088628817488dd1d5`
  - `actions/cache` → `27d5ce7f107fe9357f9df03efb73ab90386fccae` (v5.0.5)
  - `actions/setup-python` → `a309ff8b426b58ec0e2a45f0f869d46889d02405` (v6.2.0)

- [ X ] [Manual Test:](https://github.com/SolaceDev/solace-chat/actions/runs/24724740967/job/72322589966)  

