### PR TITLE
DATAGO-132821: declare mq_sha_metadata as composite output in cicd-helper

### DIFF
--- a/.github/actions/cicd-helper/action.yaml
+++ b/.github/actions/cicd-helper/action.yaml
@@ -103,6 +103,9 @@ outputs:
   RC_VERSION:
     description: "DynamoDB field value (when ddb_output_name=RC_VERSION)"
     value: ${{ steps.run_rc_helper.outputs.RC_VERSION }}
+  mq_sha_metadata:
+    description: "DynamoDB item JSON returned by get_item_by_index (when ddb_output_name=mq_sha_metadata)"
+    value: ${{ steps.run_rc_helper.outputs.mq_sha_metadata }}
   # Outputs from item_exists_in_dynamodb
   # The key name matches whatever ddb_exists_output is set to (default: ITEM_EXISTS).
   ITEM_EXISTS:


### PR DESCRIPTION
## Summary

Adds `mq_sha_metadata` to the `outputs:` block of the `cicd-helper` composite action so callers using `ddb_output_name: mq_sha_metadata` (e.g. `SolaceDev/broker`'s `check_run_handler`) can actually read the DDB item back.

## Background

PR #92 converted `cicd-helper` from `runs.using: docker` → `runs.using: composite`. Composite actions only propagate outputs that are declared statically in the top-level `outputs:` block — anything written to `$GITHUB_OUTPUT` inside a step is invisible to the caller unless explicitly mapped. The rewrite declared `MAIN_SLACK_THREAD_TS`, `MAIN_SLACK_MESSAGE`, `RC_VERSION`, and `ITEM_EXISTS`, but `mq_sha_metadata` (used by broker's merge-queue check-run handler via the `get_item_by_index` step) was not added.

As a result, callers silently lose the DDB query response: the underlying Python helper still runs, prints the manifest to stdout, but `steps.<id>.outputs.mq_sha_metadata` evaluates to empty in the caller's context.


🤖 Generated with [Claude Code](https://claude.com/claude-code)