### PR TITLE
fix(DATAGO-131317): declare missing cicd-helper composite action outputs

### DIFF
--- a/.github/actions/cicd-helper/action.yaml
+++ b/.github/actions/cicd-helper/action.yaml
@@ -97,6 +97,14 @@ outputs:
   MAIN_SLACK_MESSAGE:
     description: "Text content of the main Slack channel message"
     value: ${{ steps.run_rc_helper.outputs.MAIN_SLACK_MESSAGE }}
+  # Outputs from post_to_thread
+  THREAD_MESSAGE_TS:
+    description: "Timestamp of the thread reply message (use as thread_message_ts in update_thread_message steps)"
+    value: ${{ steps.run_rc_helper.outputs.THREAD_MESSAGE_TS }}
+  # Outputs from prepare_change_log_message
+  CHANGE_LOG_MESSAGE:
+    description: "Formatted changelog message for use as message input in subsequent post_to_channel/post_to_thread steps"
+    value: ${{ steps.run_rc_helper.outputs.CHANGE_LOG_MESSAGE }}
   # Outputs from get_item_value_from_dynamodb
   # The key name matches whatever ddb_output_name is set to by the caller.
   # Add a new entry here for each distinct ddb_output_name value used across callers.
@@ -111,6 +119,9 @@ outputs:
   ITEM_EXISTS:
     description: "DynamoDB item existence flag (when ddb_exists_output=ITEM_EXISTS)"
     value: ${{ steps.run_rc_helper.outputs.ITEM_EXISTS }}
+  SHA_PASSED_RC:
+    description: "DynamoDB item existence flag (when ddb_exists_output=SHA_PASSED_RC)"
+    value: ${{ steps.run_rc_helper.outputs.SHA_PASSED_RC }}
 
 runs:
   using: composite


### PR DESCRIPTION
## Summary

- Adds `THREAD_MESSAGE_TS` output — written by `post_to_thread` via `slack_helper.post_thread_message()`; consumed as `thread_message_ts` input in subsequent `update_thread_message` steps
- Adds `CHANGE_LOG_MESSAGE` output — written by `prepare_change_log_message`; consumed as `message` input in subsequent `post_to_channel`/`post_to_thread` steps
- Adds `SHA_PASSED_RC` output — written by `item_exists_in_dynamodb` when `ddb_exists_output: "SHA_PASSED_RC"`; used by `solace-schema-registry-java-serdes-provider` and `solace-schema-registry-dotnet-serdes-provider` release workflows

All three were confirmed by tracing every `OutputHelper.set_output()` / `_set_github_output()` call across `cicd-helper.py`, `slack_helper.py`, and `dynamodb_helper.py`.

## Test plan

- [ ] Verify `post_to_thread` step output `THREAD_MESSAGE_TS` is accessible in calling workflows via `steps.<id>.outputs.THREAD_MESSAGE_TS`
- [ ] Verify `prepare_change_log_message` step output `CHANGE_LOG_MESSAGE` is accessible in calling workflows
- [ ] Verify `item_exists_in_dynamodb` with `ddb_exists_output: SHA_PASSED_RC` is accessible in `solace-schema-registry-java-serdes-provider` and `solace-schema-registry-dotnet-serdes-provider` release workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)