### PR TITLE
fix(fossa-guard): export github_token input to GITHUB_TOKEN for docker container

### DIFF
--- a/.github/actions/fossa-guard/action.yaml
+++ b/.github/actions/fossa-guard/action.yaml
@@ -106,10 +106,6 @@ runs:
         # Use ${{ inputs.xxx }} syntax for all inputs. INPUT_* env vars are not
         # reliably set in composite action shell steps, so inline substitution
         # is the only way to ensure values are passed.
-        # GITHUB_TOKEN is NOT exported here — it is already present in the
-        # runner environment (set automatically by GitHub Actions) and is
-        # inherited by the container via -e GITHUB_TOKEN without any inline
-        # substitution, preventing its value from over-masking other outputs.
         export FOSSA_API_KEY="${{ inputs.fossa_api_key }}"
         export FOSSA_PROJECT_ID="${{ inputs.fossa_project_id }}"
         export FOSSA_CATEGORY="${{ inputs.fossa_category }}"
@@ -126,10 +122,11 @@ runs:
         [ -n "${{ inputs.github_repository }}" ]        && export GITHUB_REPOSITORY="${{ inputs.github_repository }}"
         [ -n "${{ inputs.github_run_id }}" ]            && export GITHUB_RUN_ID="${{ inputs.github_run_id }}"
         [ -n "${{ inputs.github_server_url }}" ]        && export GITHUB_SERVER_URL="${{ inputs.github_server_url }}"
-        # GITHUB_TOKEN is inherited from the runner environment via -e GITHUB_TOKEN
-        # in the docker run below — no explicit export needed. Avoiding any
-        # inline expression substitution for the token prevents its value from
-        # being registered for masking (which would over-mask branch/project values).
+        # Export the github_token input to GITHUB_TOKEN so the container receives it.
+        # runs.using: docker injected this automatically; with composite + docker run
+        # we must do it explicitly. The input defaults to github.token so it is
+        # always set. GitHub will mask the token value in logs, which is correct.
+        export GITHUB_TOKEN="${{ inputs.github_token }}"
         [ -n "${{ inputs.enable_pr_comment }}" ]        && export ENABLE_PR_COMMENT="${{ inputs.enable_pr_comment }}"
         [ -n "${{ inputs.enable_status_check }}" ]      && export ENABLE_STATUS_CHECK="${{ inputs.enable_status_check }}"
         [ -n "${{ inputs.status_check_name }}" ]        && export STATUS_CHECK_NAME="${{ inputs.status_check_name }}"

--- a/.github/workflows/sca-scan-and-guard.yaml
+++ b/.github/workflows/sca-scan-and-guard.yaml
@@ -545,7 +545,7 @@ jobs:
 
       - name: FOSSA Policy/Licensing Check
         id: fossa_licensing
-        uses: SolaceDev/solace-public-workflows/.github/actions/fossa-guard@main
+        uses: SolaceDev/solace-public-workflows/.github/actions/fossa-guard@fix/fossa-guard-github-token-passthrough
         continue-on-error: true
         with:
           fossa_api_key: ${{ steps.fossa_key.outputs.FOSSA_KEY }}
@@ -564,7 +564,7 @@ jobs:
 
       - name: FOSSA Vulnerability Check
         id: fossa_vulnerabilities
-        uses: SolaceDev/solace-public-workflows/.github/actions/fossa-guard@main
+        uses: SolaceDev/solace-public-workflows/.github/actions/fossa-guard@fix/fossa-guard-github-token-passthrough
         continue-on-error: true
         with:
           fossa_api_key: ${{ steps.fossa_key.outputs.FOSSA_KEY }}


### PR DESCRIPTION
## Summary

- `runs.using: docker` automatically injected `GITHUB_TOKEN` into the container; after the refactor to `runs.using: composite` + explicit `docker run`, the `-e GITHUB_TOKEN` flag relies on the runner shell env — but `GITHUB_TOKEN` is a secret, not an automatic shell env var, so the container was receiving nothing
- Explicitly export `inputs.github_token` to `GITHUB_TOKEN` before `docker run`, consistent with how every other input is handled
- Remove the now-incorrect comments claiming the runner env would supply the token

## Test plan

- [ ] Trigger a `fossa-guard` run with `enable_pr_comment: true` or `enable_status_check: true` and confirm the warnings `GITHUB_TOKEN not set, cannot create PR comment / status check` are gone
- [ ] Confirm PR comment / status check are created as expected
- [ ] Confirm no regression for runs where `enable_pr_comment` and `enable_status_check` are both `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)