### PR TITLE
fix: refer to main branch after sca-scan-and-guard gh token update

### DIFF
--- a/.github/actions/fossa-guard/action.yaml
+++ b/.github/actions/fossa-guard/action.yaml
@@ -106,10 +106,6 @@ runs:
         # Use ${{ inputs.xxx }} syntax for all inputs. INPUT_* env vars are not
         # reliably set in composite action shell steps, so inline substitution
         # is the only way to ensure values are passed.
-        # GITHUB_TOKEN is NOT exported here — it is already present in the
-        # runner environment (set automatically by GitHub Actions) and is
-        # inherited by the container via -e GITHUB_TOKEN without any inline
-        # substitution, preventing its value from over-masking other outputs.
         export FOSSA_API_KEY="${{ inputs.fossa_api_key }}"
         export FOSSA_PROJECT_ID="${{ inputs.fossa_project_id }}"
         export FOSSA_CATEGORY="${{ inputs.fossa_category }}"
@@ -126,10 +122,11 @@ runs:
         [ -n "${{ inputs.github_repository }}" ]        && export GITHUB_REPOSITORY="${{ inputs.github_repository }}"
         [ -n "${{ inputs.github_run_id }}" ]            && export GITHUB_RUN_ID="${{ inputs.github_run_id }}"
         [ -n "${{ inputs.github_server_url }}" ]        && export GITHUB_SERVER_URL="${{ inputs.github_server_url }}"
-        # GITHUB_TOKEN is inherited from the runner environment via -e GITHUB_TOKEN
-        # in the docker run below — no explicit export needed. Avoiding any
-        # inline expression substitution for the token prevents its value from
-        # being registered for masking (which would over-mask branch/project values).
+        # Export the github_token input to GITHUB_TOKEN so the container receives it.
+        # runs.using: docker injected this automatically; with composite + docker run
+        # we must do it explicitly. The input defaults to github.token so it is
+        # always set. GitHub will mask the token value in logs, which is correct.
+        export GITHUB_TOKEN="${{ inputs.github_token }}"
         [ -n "${{ inputs.enable_pr_comment }}" ]        && export ENABLE_PR_COMMENT="${{ inputs.enable_pr_comment }}"
         [ -n "${{ inputs.enable_status_check }}" ]      && export ENABLE_STATUS_CHECK="${{ inputs.enable_status_check }}"
         [ -n "${{ inputs.status_check_name }}" ]        && export STATUS_CHECK_NAME="${{ inputs.status_check_name }}"

--- a/.github/workflows/sca-scan-and-guard.yaml
+++ b/.github/workflows/sca-scan-and-guard.yaml
@@ -545,7 +545,7 @@ jobs:
 
       - name: FOSSA Policy/Licensing Check
         id: fossa_licensing
-        uses: SolaceDev/solace-public-workflows/.github/actions/fossa-guard@main
+        uses: SolaceDev/solace-public-workflows/.github/actions/fossa-guard@fix/fossa-guard-github-token-passthrough
         continue-on-error: true
         with:
           fossa_api_key: ${{ steps.fossa_key.outputs.FOSSA_KEY }}
@@ -564,7 +564,7 @@ jobs:
 
       - name: FOSSA Vulnerability Check
         id: fossa_vulnerabilities
-        uses: SolaceDev/solace-public-workflows/.github/actions/fossa-guard@main
+        uses: SolaceDev/solace-public-workflows/.github/actions/fossa-guard@fix/fossa-guard-github-token-passthrough
         continue-on-error: true
         with:
           fossa_api_key: ${{ steps.fossa_key.outputs.FOSSA_KEY }}


### PR DESCRIPTION
This pull request updates the FOSSA guard GitHub Action to ensure the `GITHUB_TOKEN` is properly passed to the container when using a composite action. It also updates workflow references to use a branch with the token passthrough fix. The main goal is to make sure the action receives the correct GitHub token for authentication, especially when running in composite+docker contexts.

**GitHub Action updates:**

* [`.github/actions/fossa-guard/action.yaml`](diffhunk://#diff-c1aa956fd387870c7df5d8e75101013dcd75a0d947817238d8b64d1c7b7a9b54L109-L112): Now explicitly exports the `github_token` input as `GITHUB_TOKEN` so the container receives it. This replaces the previous reliance on the runner environment and fixes issues with token masking and availability in composite actions. [[1]](diffhunk://#diff-c1aa956fd387870c7df5d8e75101013dcd75a0d947817238d8b64d1c7b7a9b54L109-L112) [[2]](diffhunk://#diff-c1aa956fd387870c7df5d8e75101013dcd75a0d947817238d8b64d1c7b7a9b54L129-R129)

**Workflow reference updates:**

* [`.github/workflows/sca-scan-and-guard.yaml`](diffhunk://#diff-80bd12ff05db4c092dbae823be7803baa01c5a19bbdfb74e5988e0f8357134ecL548-R548): Updates both the "FOSSA Policy/Licensing Check" and "FOSSA Vulnerability Check" steps to use the `fix/fossa-guard-github-token-passthrough` branch of the FOSSA guard action, ensuring the workflow uses the version with the token passthrough fix. [[1]](diffhunk://#diff-80bd12ff05db4c092dbae823be7803baa01c5a19bbdfb74e5988e0f8357134ecL548-R548) [[2]](diffhunk://#diff-80bd12ff05db4c092dbae823be7803baa01c5a19bbdfb74e5988e0f8357134ecL567-R567)
