### PR TITLE
fix: refer to main branch for sca-scan-and-guard

### DIFF
--- a/.github/workflows/sca-scan-and-guard.yaml
+++ b/.github/workflows/sca-scan-and-guard.yaml
@@ -545,7 +545,7 @@ jobs:
 
       - name: FOSSA Policy/Licensing Check
         id: fossa_licensing
-        uses: SolaceDev/solace-public-workflows/.github/actions/fossa-guard@fix/fossa-guard-github-token-passthrough
+        uses: SolaceDev/solace-public-workflows/.github/actions/fossa-guard@main
         continue-on-error: true
         with:
           fossa_api_key: ${{ steps.fossa_key.outputs.FOSSA_KEY }}
@@ -564,7 +564,7 @@ jobs:
 
       - name: FOSSA Vulnerability Check
         id: fossa_vulnerabilities
-        uses: SolaceDev/solace-public-workflows/.github/actions/fossa-guard@fix/fossa-guard-github-token-passthrough
+        uses: SolaceDev/solace-public-workflows/.github/actions/fossa-guard@main
         continue-on-error: true
         with:
           fossa_api_key: ${{ steps.fossa_key.outputs.FOSSA_KEY }}


### PR DESCRIPTION
This pull request updates the FOSSA policy/licensing and vulnerability check steps in the `.github/workflows/sca-scan-and-guard.yaml` workflow to use the latest stable version of the `fossa-guard` GitHub Action. The action reference is changed from a feature branch to the `main` branch, ensuring the workflow uses the most up-to-date and supported version.

**Workflow dependency updates:**

* Updated the `FOSSA Policy/Licensing Check` step to use `SolaceDev/solace-public-workflows/.github/actions/fossa-guard@main` instead of the `fix/fossa-guard-github-token-passthrough` branch.
* Updated the `FOSSA Vulnerability Check` step to use `SolaceDev/solace-public-workflows/.github/actions/fossa-guard@main` instead of the `fix/fossa-guard-github-token-passthrough` branch.