### PR TITLE
fix(DATAGO-133953): skip Guardian upload on pull_request events

### DIFF
--- a/.github/actions/sca/fossa-scan/action.yaml
+++ b/.github/actions/sca/fossa-scan/action.yaml
@@ -68,7 +68,7 @@ runs:
         echo "::endgroup::"
 
     - name: Fossa - Upload to Guardian
-      if: ${{ always() && inputs.guardian_url != ''}}
+      if: ${{ always() && inputs.guardian_url != '' && github.event_name != 'pull_request' }}
       continue-on-error: true
       shell: bash
       env:


### PR DESCRIPTION
## Summary
- The `Fossa - Upload to Guardian` step in `fossa-scan/action.yaml` had no guard against PR context
- FOSSA scan results were being uploaded to Guardian on every PR scan, which should only happen for release/manual scans
- Added `github.event_name != 'pull_request'` to the step condition

## Changes
- `.github/actions/sca/fossa-scan/action.yaml`: added `&& github.event_name != 'pull_request'` to the upload step `if` condition

## Test plan
- [ ] Trigger a PR scan — verify the `Fossa - Upload to Guardian` step is skipped
- [ ] Trigger a release/manual scan — verify the upload step still runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)