### PR TITLE
fix(DATAGO-134070): fix fossa upload on release-please pr's

### DIFF
--- a/.github/actions/sca/fossa-scan/action.yaml
+++ b/.github/actions/sca/fossa-scan/action.yaml
@@ -10,6 +10,10 @@ inputs:
     description: "Bearer token for Guardian API authentication."
     required: false
     default: ""
+  pr_scan_upload:
+    description: "Upload scan results to Guardian even on pull_request events (default: false)."
+    required: false
+    default: "false"
 runs:
   using: "composite"
   steps:
@@ -68,7 +72,7 @@ runs:
         echo "::endgroup::"
 
     - name: Fossa - Upload to Guardian
-      if: ${{ always() && inputs.guardian_url != '' && github.event_name != 'pull_request' }}
+      if: ${{ always() && inputs.guardian_url != '' && (github.event_name != 'pull_request' || inputs.pr_scan_upload == 'true') }}
       continue-on-error: true
       shell: bash
       env:

--- a/.github/actions/sca/sca-scan/action.yaml
+++ b/.github/actions/sca/sca-scan/action.yaml
@@ -30,6 +30,10 @@ inputs:
     description: "Bearer token for Guardian API authentication."
     required: false
     default: ""
+  pr_scan_upload:
+    description: "Upload scan results to Guardian even on pull_request events (default: false)."
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -79,5 +83,6 @@ runs:
       with:
         guardian_url: ${{ inputs.guardian_url }}
         guardian_token: ${{ inputs.guardian_token }}
+        pr_scan_upload: ${{ inputs.pr_scan_upload }}
       env:
         FOSSA_API_KEY: ${{ inputs.fossa_api_key }}

--- a/.github/workflows/sca-scan-and-guard.yaml
+++ b/.github/workflows/sca-scan-and-guard.yaml
@@ -289,6 +289,7 @@ jobs:
           CONFIG_FOSSA_TEAM: ${{ steps.config_loader.outputs.fossa_team }}
           CONFIG_FOSSA_LABELS: ${{ steps.config_loader.outputs.fossa_labels }}
           CONFIG_GUARDIAN_URL: ${{ steps.config_loader.outputs.guardian_url }}
+          CONFIG_GUARDIAN_PR_SCAN_UPLOAD: ${{ steps.config_loader.outputs.guardian_pr_scan_upload }}
         run: |
           # Priority: config file > defaults
           if [[ -n "$CONFIG_FILE" ]]; then
@@ -313,6 +314,7 @@ jobs:
             echo "fossa_team=${CONFIG_FOSSA_TEAM}" >> $GITHUB_OUTPUT
             echo "fossa_labels=${CONFIG_FOSSA_LABELS}" >> $GITHUB_OUTPUT
             echo "guardian_url=${CONFIG_GUARDIAN_URL}" >> $GITHUB_OUTPUT
+            echo "guardian_pr_scan_upload=${CONFIG_GUARDIAN_PR_SCAN_UPLOAD}" >> $GITHUB_OUTPUT
           else
             echo "📝 Using default configuration"
             echo "vault_url=" >> $GITHUB_OUTPUT
@@ -328,6 +330,7 @@ jobs:
             echo "fossa_team=" >> $GITHUB_OUTPUT
             echo "fossa_labels=" >> $GITHUB_OUTPUT
             echo "guardian_url=" >> $GITHUB_OUTPUT
+            echo "guardian_pr_scan_upload=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Validate Vault Configuration
@@ -542,6 +545,7 @@ jobs:
           fossa_api_key: ${{ steps.fossa_key.outputs.FOSSA_KEY }}
           guardian_url: ${{ steps.guardian_key.outputs.GUARDIAN_URL }}
           guardian_token: ${{ steps.guardian_key.outputs.GUARDIAN_TOKEN }}
+          pr_scan_upload: ${{ steps.config.outputs.guardian_pr_scan_upload }}
 
       - name: FOSSA Policy/Licensing Check
         id: fossa_licensing

--- a/workflow-config-loader/action.yaml
+++ b/workflow-config-loader/action.yaml
@@ -56,6 +56,9 @@ outputs:
   guardian_url:
     description: "Guardian API base URL"
     value: ${{ steps.parse.outputs.guardian_url }}
+  guardian_pr_scan_upload:
+    description: "Whether to upload scan results to Guardian on pull_request events (default: false)"
+    value: ${{ steps.parse.outputs.guardian_pr_scan_upload }}
 
 runs:
   using: "composite"
@@ -168,6 +171,10 @@ runs:
         GUARDIAN_URL=$(echo "$CONFIG" | jq -r ".${CONFIG_TYPE}.guardian.url // \"\"")
         echo "guardian_url=${GUARDIAN_URL}" >> $GITHUB_OUTPUT
 
+        # Parse Guardian PR scan upload flag
+        GUARDIAN_PR_UPLOAD=$(echo "$CONFIG" | jq -r ".${CONFIG_TYPE}.guardian.pr_scan_upload // false")
+        echo "guardian_pr_scan_upload=${GUARDIAN_PR_UPLOAD}" >> $GITHUB_OUTPUT
+
         echo "✅ Configuration parsed successfully"
         echo ""
         echo "Parsed values:"
@@ -182,3 +189,4 @@ runs:
         echo "  - FOSSA team: ${FOSSA_TEAM:-<not set>}"
         echo "  - FOSSA labels: ${FOSSA_LABELS:-<not set>}"
         echo "  - Guardian URL: $([ -n "${GUARDIAN_URL}" ] && echo '<set>' || echo '<not set>')"
+        echo "  - Guardian PR scan upload: ${GUARDIAN_PR_UPLOAD}"


### PR DESCRIPTION
## Summary

Fixes FOSSA scan results not being uploaded to Guardian during release-please pull request events.

### What is the purpose of this change?

Previously, the FOSSA Guardian upload step was unconditionally skipped for all `pull_request` events. This meant that release-please PRs — which are important to track for SCA compliance — were also excluded from uploading scan results to Guardian.

### How is this accomplished?

- Adds a new `pr_scan_upload` input parameter threaded through `fossa-scan`, `sca-scan`, and the `sca-scan-and-guard` workflow, allowing callers to opt in to Guardian uploads on pull request events.
- Updates the conditional in the "Fossa - Upload to Guardian" step to allow uploads when `pr_scan_upload` is `'true'`, even on `pull_request` events.
- Extends the `workflow-config-loader` to parse a new `guardian.pr_scan_upload` field from the workflow config file and propagate it as an output.
- Defaults to `false` everywhere to preserve existing behavior for regular PRs.

### Anything reviewers should focus on/be aware of?

- The default remains `false`, so this is a non-breaking change — only repositories that explicitly set `guardian.pr_scan_upload: true` in their config will see different behavior.
- Verify the `jq` default (`// false`) in `workflow-config-loader` produces the expected string value when the field is absent from the config file.
