### PR TITLE
feat: add repo input

### DIFF
--- a/generate-github-release-notes/action.yaml
+++ b/generate-github-release-notes/action.yaml
@@ -34,6 +34,10 @@ inputs:
   github-token:
     description: "GitHub token for API access (requires contents:read, pull-requests:read, metadata:read permissions)"
     required: true
+  repository:
+    description: "Repository in 'owner/repo' format. Defaults to the current repository (GITHUB_REPOSITORY)"
+    required: false
+    default: ""
 
 outputs:
   release-notes-path:
@@ -46,6 +50,7 @@ runs:
   image: "Dockerfile"
   env:
     GITHUB_TOKEN: ${{ inputs.github-token }}
+    INPUT_REPOSITORY: ${{ inputs.repository }}
   args:
     - ${{ inputs.from-ref }}
     - ${{ inputs.to-ref }}

--- a/generate-github-release-notes/generate-github-release-notes.py
+++ b/generate-github-release-notes/generate-github-release-notes.py
@@ -61,17 +61,22 @@ def load_version_config(config_file_path: str = DEFAULT_VERSION_CONFIG_FILE) -> 
         sys.exit(1)
 
 
+def _resolve_repository() -> str:
+    """Return the target repository, preferring INPUT_REPOSITORY over GITHUB_REPOSITORY."""
+    repo = getenv("INPUT_REPOSITORY") or getenv("GITHUB_REPOSITORY")
+    if not repo:
+        print("Error: Neither INPUT_REPOSITORY nor GITHUB_REPOSITORY environment variable is set")
+        sys.exit(1)
+    return repo
+
+
 def _validate_environment() -> tuple[str, str]:
     """Validate required environment variables"""
     github_token = getenv("GITHUB_TOKEN")
-    github_repo = getenv("GITHUB_REPOSITORY")
+    github_repo = _resolve_repository()
 
     if not github_token:
         print("Error: GITHUB_TOKEN environment variable not set")
-        sys.exit(1)
-
-    if not github_repo:
-        print("Error: GITHUB_REPOSITORY environment variable not set")
         sys.exit(1)
 
     return github_token, github_repo
@@ -919,12 +924,7 @@ def process_commits(commits: list[dict], config: dict) -> tuple[dict, dict]:
 
 def _get_repo_url() -> str:
     """Get repository URL from environment variables"""
-    github_repo = getenv("GITHUB_REPOSITORY")
-    if not github_repo:
-        print("Error: GITHUB_REPOSITORY environment variable not set")
-        sys.exit(1)
-
-    return f"https://github.com/{github_repo}"
+    return f"https://github.com/{_resolve_repository()}"
 
 
 def _format_commit_hash(commit: dict, repo_url: str) -> str:


### PR DESCRIPTION
## Summary
Add an optional `repository` input to the `generate-github-release-notes` action, allowing it to generate release notes for a repository other than the current one.

### What is the purpose of this change?

Allow callers of the `generate-github-release-notes` action to specify a target repository in `owner/repo` format instead of being limited to the repository the workflow is running in (`GITHUB_REPOSITORY`).

### How is this accomplished?

- Add a new optional `repository` input to `action.yaml` that defaults to an empty string and is passed as the `INPUT_REPOSITORY` environment variable.
- Introduce a `_resolve_repository()` helper in the Python script that prefers `INPUT_REPOSITORY` over `GITHUB_REPOSITORY`, centralizing repository resolution logic.
- Refactor `_validate_environment()` and `_get_repo_url()` to use `_resolve_repository()`, removing duplicated `GITHUB_REPOSITORY` lookups and error handling.

### Anything reviews should focus on/be aware of?

- When `repository` is not provided the behaviour is unchanged — `GITHUB_REPOSITORY` is used as before.
- The `GITHUB_TOKEN` must still have appropriate permissions on the target repository when a custom value is supplied.
