### PR TITLE
chore(DATAGO-136272): bump maas-build-actions image to inherit fossa-guard fix

### DIFF
--- a/.github/actions/fossa-guard/action.yaml
+++ b/.github/actions/fossa-guard/action.yaml
@@ -178,5 +178,5 @@ runs:
           -v "${RUNNER_TEMP}:${RUNNER_TEMP}" \
           -v "${GITHUB_OUTPUT_DIR}:${GITHUB_OUTPUT_DIR}" \
           --workdir /github/workspace \
-          "ghcr.io/${OWNER}/maas-build-actions@sha256:96f6a7276d96f888a1848db1d57715316054d0907471bd227a8eb737559fda3c" \
+          "ghcr.io/${OWNER}/maas-build-actions@sha256:15c44ebad24e907c5691a136e7170a5e665f540e244446d82c33112b7ce050cd" \
           /bin/sh -c 'source /maas-build-actions/venv/bin/activate && python3 /maas-build-actions/scripts/fossa-guard/fossa_guard.py'

--- a/.github/workflows/hatch_release_pypi.yml
+++ b/.github/workflows/hatch_release_pypi.yml
@@ -161,7 +161,7 @@ jobs:
             -e GH_ORG \
             -e GH_REPO \
             -e GITHUB_SHA \
-            ghcr.io/${OWNER}/maas-build-actions@sha256:96f6a7276d96f888a1848db1d57715316054d0907471bd227a8eb737559fda3c \
+            ghcr.io/${OWNER}/maas-build-actions@sha256:15c44ebad24e907c5691a136e7170a5e665f540e244446d82c33112b7ce050cd \
             /bin/sh -c '. $VIRTUAL_ENV/bin/activate && cd $ACTIONS_PATH/prisma-vulnerability-checker && python prisma_vulnerability_checker.py'
       - name: Run SonarQube Hotspot Check
         if: ${{ fromJson(inputs.sonarqube_hotspot_check) }}
@@ -181,7 +181,7 @@ jobs:
             -e SONARQUBE_PROJECT_MAIN_BRANCH \
             -e SONARQUBE_QUERY_TOKEN \
             -e SONARQUBE_HOTSPOTS_API_URL \
-            ghcr.io/${OWNER}/maas-build-actions@sha256:96f6a7276d96f888a1848db1d57715316054d0907471bd227a8eb737559fda3c \
+            ghcr.io/${OWNER}/maas-build-actions@sha256:15c44ebad24e907c5691a136e7170a5e665f540e244446d82c33112b7ce050cd \
             /bin/sh -c '. $VIRTUAL_ENV/bin/activate && cd $ACTIONS_PATH/sonarqube-hotspot-checker && python sonarqube_checker.py'
 
       - name: Setup Node.js

--- a/.github/workflows/hatch_release_security_checks.yml
+++ b/.github/workflows/hatch_release_security_checks.yml
@@ -136,7 +136,7 @@ jobs:
             -e GH_ORG \
             -e GH_REPO \
             -e GITHUB_SHA \
-            ghcr.io/${OWNER}/maas-build-actions@sha256:96f6a7276d96f888a1848db1d57715316054d0907471bd227a8eb737559fda3c \
+            ghcr.io/${OWNER}/maas-build-actions@sha256:15c44ebad24e907c5691a136e7170a5e665f540e244446d82c33112b7ce050cd \
             /bin/sh -c '. $VIRTUAL_ENV/bin/activate && cd $ACTIONS_PATH/prisma-vulnerability-checker && python prisma_vulnerability_checker.py'
 
       - name: Run SonarQube Hotspot Check
@@ -159,5 +159,5 @@ jobs:
             -e SONARQUBE_PROJECT_MAIN_BRANCH \
             -e SONARQUBE_QUERY_TOKEN \
             -e SONARQUBE_HOTSPOTS_API_URL \
-            ghcr.io/${OWNER}/maas-build-actions@sha256:96f6a7276d96f888a1848db1d57715316054d0907471bd227a8eb737559fda3c \
+            ghcr.io/${OWNER}/maas-build-actions@sha256:15c44ebad24e907c5691a136e7170a5e665f540e244446d82c33112b7ce050cd \
             /bin/sh -c '. $VIRTUAL_ENV/bin/activate && cd $ACTIONS_PATH/sonarqube-hotspot-checker && python sonarqube_checker.py'


### PR DESCRIPTION
## Summary

- Updates 5 stale references from the Apr 20 image (`sha256:96f6a72`) to the Apr 24 image (`sha256:15c44eb`) across `fossa-guard`, `hatch_release_security_checks`, and `hatch_release_pypi`
- The Apr 24 image includes the FOSSA scan ID auto-resolution fix: `get_latest_scan_id_for_revision` now correctly resolves the latest scan for a PR revision instead of falling back to stale cached data from a different branch

## What was not changed

- `generate-fossa-report/action.yaml` uses a separate SHA (`bf604b23`, Apr 9 build) — left unchanged, verify separately if needed
- `cicd-helper/action.yaml` was already on the Apr 24 image



🤖 Generated with [Claude Code](https://claude.com/claude-code)