### PR TITLE
feat(prisma-cloud-scan): add bypass_blocking input

### DIFF
--- a/prisma-cloud-scan/README.md
+++ b/prisma-cloud-scan/README.md
@@ -156,6 +156,7 @@ jobs:
 | `twistcli_publish` | No | `true` | Whether to publish scan results to Prisma Cloud Console (`true`/`false`) |
 | `block_on_compliance` | No | `false` | Block on high/critical compliance findings (`true`/`false`) |
 | `vulnerability_grace_period_days` | No | `7` | Grace period for new vulnerabilities before they become blocking |
+| `bypass_blocking` | No | `false` | Bypass all release-blocking logic; action exits 0 regardless of findings. Use to consume scan outputs without failing the step (`scan_passed` still reflects the real policy result). |
 | `skip_image_pull` | No | `false` | Skip Docker pull and scan image already present locally |
 | `show_detailed_logs` | No | auto | Force detailed logs (`true`/`false`). Auto mode = hidden for public repos, shown otherwise |
 | `guardian_url` | No | empty | Guardian API base URL. When set with `guardian_key`, uploads normalized Prisma results to Guardian |

--- a/prisma-cloud-scan/action.yml
+++ b/prisma-cloud-scan/action.yml
@@ -419,6 +419,7 @@ runs:
         TARGET_SHA: ${{ steps.scan_image.outputs.target_sha }}
         PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         GUARDIAN_ENABLED: ${{ inputs.guardian_url != '' && inputs.guardian_key != '' && 'true' || 'false' }}
+        BYPASS_BLOCKING: ${{ inputs.bypass_blocking }}
         CONSOLE_LINK: ${{ steps.scan_image.outputs.console_link }}
         PCC_CONSOLE_URL: ${{ inputs.pcc_console_url }}
         FALLBACK_IMAGE: ${{ inputs.image_registry }}/${{ steps.set_repo_name.outputs.repo_name }}:${{ inputs.image_tag }}

--- a/prisma-cloud-scan/action.yml
+++ b/prisma-cloud-scan/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: "Grace period in days for new vulnerabilities before blocking (0 to block immediately). Ignored when Guardian upload is enabled."
     required: false
     default: "7"
+  bypass_blocking:
+    description: "Bypass all release-blocking logic. When true, the action never exits non-zero based on scan findings (vulnerabilities or compliance). Use when you only need the scan outputs for downstream processing."
+    required: false
+    default: "false"
   skip_image_pull:
     description: "Skip pulling the image (use when image is already available locally)"
     required: false
@@ -393,6 +397,7 @@ runs:
       env:
         BLOCK_ON_COMPLIANCE: ${{ inputs.block_on_compliance }}
         GRACE_PERIOD_DAYS: ${{ inputs.vulnerability_grace_period_days }}
+        BYPASS_BLOCKING: ${{ inputs.bypass_blocking }}
         GUARDIAN_ENABLED: ${{ inputs.guardian_url != '' && inputs.guardian_key != '' && 'true' || 'false' }}
         CONSOLE_LINK: ${{ steps.scan_image.outputs.console_link }}
         PCC_CONSOLE_URL: ${{ inputs.pcc_console_url }}

--- a/prisma-cloud-scan/scripts/analyze_scan_results.py
+++ b/prisma-cloud-scan/scripts/analyze_scan_results.py
@@ -113,6 +113,7 @@ def main() -> int:
 
     block_on_compliance = to_bool(os.getenv("BLOCK_ON_COMPLIANCE"), default=False)
     grace_period_days = to_int(os.getenv("GRACE_PERIOD_DAYS"), default=7)
+    bypass_blocking = to_bool(os.getenv("BYPASS_BLOCKING"), default=False)
     guardian_managed_vulnerabilities = to_bool(os.getenv("GUARDIAN_ENABLED"), default=False)
     grace_period_seconds = grace_period_days * 86400
     current_timestamp = int(datetime.now(tz=timezone.utc).timestamp())
@@ -123,6 +124,7 @@ def main() -> int:
     print("Configuration:")
     print(f"  Block on compliance: {str(block_on_compliance).lower()}")
     print(f"  Vulnerability grace period: {grace_period_days} days")
+    print(f"  Bypass blocking: {str(bypass_blocking).lower()}")
     print(
         "  Vulnerability blocking delegated to Guardian: "
         f"{str(guardian_managed_vulnerabilities).lower()}"
@@ -340,9 +342,16 @@ def main() -> int:
         "blocking_total": blocking_total,
         "grace_days": grace_period_days,
         "block_on_compliance": block_on_compliance,
+        "bypass_blocking": bypass_blocking,
         "guardian_managed_vulnerabilities": guardian_managed_vulnerabilities,
     }
     write_analysis_file(analysis)
+
+    if blocking_issues and bypass_blocking:
+        print("")
+        print("⚠️  Blocking issues found, but bypass_blocking=true — action will not fail the step.")
+        print("   Downstream workflows are responsible for acting on the scan_passed output.")
+        return 0
 
     if blocking_issues:
         print("")

--- a/prisma-cloud-scan/scripts/post_prisma_check_run.py
+++ b/prisma-cloud-scan/scripts/post_prisma_check_run.py
@@ -463,7 +463,13 @@ def main() -> int:
     analysis = read_analysis_results()
 
     scan_passed = to_bool(analysis.get("scan_passed"), default=bool_env("SCAN_PASSED", default=False))
-    conclusion = "success" if scan_passed else "failure"
+    bypass_blocking = to_bool(analysis.get("bypass_blocking"), default=bool_env("BYPASS_BLOCKING", default=False))
+    if scan_passed:
+        conclusion = "success"
+    elif bypass_blocking:
+        conclusion = "neutral"
+    else:
+        conclusion = "failure"
     guardian_managed_vulnerabilities = to_bool(
         analysis.get("guardian_managed_vulnerabilities"),
         default=bool_env("GUARDIAN_ENABLED", default=False),
@@ -599,7 +605,13 @@ def main() -> int:
         "conclusion": conclusion,
         "details_url": target_url,
         "output": {
-            "title": "✅ Prisma Image Scan passed" if scan_passed else "❌ Prisma Image Scan failed",
+            "title": (
+                "✅ Prisma Image Scan passed"
+                if scan_passed
+                else "⚪ Prisma Image Scan (bypassed)"
+                if bypass_blocking
+                else "❌ Prisma Image Scan failed"
+            ),
             "summary": summary_markdown,
             "text": details_text,
         },


### PR DESCRIPTION
Adds a `bypass_blocking` input to the prisma-cloud-scan action so callers can consume scan outputs (`scan_passed`, `vuln_*`) without failing the step. When true, the analysis script returns 0 even with blocking findings, and the GitHub Check Run is posted as `neutral` instead of `failure`. `scan_passed` still reflects the real policy result so downstream workflows can gate on it.