### PR TITLE
feat(DATAGO-137108): add guardian-vulnerability-diff composite action

### DIFF
--- a/guardian-vulnerability-diff/README.md
+++ b/guardian-vulnerability-diff/README.md
@@ -1,0 +1,56 @@
+# Guardian Vulnerability Diff
+
+Calls Guardian `POST /api/v1/vulnerability-diff` with a Prisma scan from a PR build, compares it against the live baseline for the product, and posts the rendered markdown summary back as a PR comment.
+
+Use this action on pull requests to surface CVEs added, resolved, or changed by the build under review. To gate merges on net-new vulnerabilities use `guardian-vulnerability-gate` instead — vulnerability-diff is informational by default but can fail the run when new Critical CVEs are introduced.
+
+## Required Inputs
+
+- `guardian-url`
+- `guardian-key`
+- `prisma-scan-path`
+
+## Optional Inputs
+
+- `product-name` — defaults to `${GITHUB_REPOSITORY#*/}`
+- `verbosity` — `summary` | `compact` | `detailed`. Default: `detailed`
+- `post-comment` — default: `true`. When `true` and the run is on a `pull_request`, post `comment_markdown` as a PR comment. Existing comments are detected via marker and updated rather than duplicated.
+- `fail-on-added-critical` — default: `false`. Exit non-zero when `by_severity.Critical.added > 0`.
+- `debug` — default: `false`. Pass through `?debug=true` and dump the diagnostics block to the workflow log.
+- `github-token` — defaults to `${{ github.token }}`; used by the PR-comment step.
+- `upload-logs` — default: `false`. Uploads the response JSON and rendered comment as a workflow artifact.
+
+## Outputs
+
+- `added_count`, `resolved_count`, `changed_count`, `critical_added_count`
+- `response_json` — compact JSON response (omitted when >50KB)
+- `comment_url` — set when a PR comment was posted or updated
+
+## Example
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+
+steps:
+  - name: Vulnerability diff vs live baseline
+    id: guardian-diff
+    uses: SolaceDev/solace-public-workflows/guardian-vulnerability-diff@main
+    with:
+      guardian-url: ${{ secrets.GUARDIAN_API_URL }}
+      guardian-key: ${{ secrets.GUARDIAN_API_TOKEN }}
+      prisma-scan-path: ./prisma_scan.json
+      product-name: harness-delegate
+      verbosity: detailed
+      fail-on-added-critical: "true"
+```
+
+## Notes
+
+- The endpoint accepts the twistcli envelope (`{"consoleURL": …, "results": […]}`), the bare `results` body, or an already-unwrapped list.
+- `product-name` must resolve to a vulnerabilities collection in the deployed Mongo `products` collection. Missing config returns 404.
+- Baseline is filtered to CVEs whose `reporting_scanners` contains `prisma`. CVEs surfaced by other scanners only are intentionally invisible — they will appear in `notes[]` on the response and in the step summary.
+- The PR-comment step needs `pull-requests: write` on the workflow `permissions:` block.
+- The action runs `--render_markdown=true` unconditionally so `comment_markdown` is always populated; control how verbose that markdown is with `verbosity`.
+- Workflow permissions for the calling job must include `pull-requests: write` when `post-comment: "true"`.

--- a/guardian-vulnerability-diff/README.md
+++ b/guardian-vulnerability-diff/README.md
@@ -19,6 +19,7 @@ Use this action on pull requests to surface CVEs added, resolved, or changed by 
 - `debug` — default: `false`. Pass through `?debug=true` and dump the diagnostics block to the workflow log.
 - `github-token` — defaults to `${{ github.token }}`; used by the PR-comment step.
 - `upload-logs` — default: `false`. Uploads the response JSON and rendered comment as a workflow artifact.
+- `publish-report` — default: `true`. When `false`, suppresses the PR comment, the detailed step-summary table, the diagnostics dump, and the log artifact. **Always suppressed for public repositories regardless of this flag.**
 
 ## Outputs
 
@@ -52,5 +53,6 @@ steps:
 - `product-name` must resolve to a vulnerabilities collection in the deployed Mongo `products` collection. Missing config returns 404.
 - Baseline is filtered to CVEs whose `reporting_scanners` contains `prisma`. CVEs surfaced by other scanners only are intentionally invisible — they will appear in `notes[]` on the response and in the step summary.
 - The PR-comment step needs `pull-requests: write` on the workflow `permissions:` block.
+- **Public repositories**: vulnerability detail (PR comment, detailed step summary, diagnostics, log artifact) is always suppressed. Numeric `*_count` outputs and the compact `response_json` step output are still emitted so downstream gating in the same workflow keeps working. Override is not available — keep details out of public surfaces.
 - The action runs `--render_markdown=true` unconditionally so `comment_markdown` is always populated; control how verbose that markdown is with `verbosity`.
 - Workflow permissions for the calling job must include `pull-requests: write` when `post-comment: "true"`.

--- a/guardian-vulnerability-diff/action.yml
+++ b/guardian-vulnerability-diff/action.yml
@@ -35,6 +35,10 @@ inputs:
     description: "Token used by the PR-comment step. Defaults to the workflow token."
     required: false
     default: ${{ github.token }}
+  issue-number:
+    description: "Explicit PR/issue number to comment on. When set, the comment is posted regardless of github.event_name. Useful when the action is invoked from workflow_run."
+    required: false
+    default: ""
   upload-logs:
     description: "Upload vulnerability-diff response and rendered comment as a workflow artifact."
     required: false
@@ -130,10 +134,11 @@ runs:
 
     - name: Post PR comment
       id: post_comment
-      if: ${{ success() && inputs.post-comment == 'true' && github.event_name == 'pull_request' }}
+      if: ${{ success() && inputs.post-comment == 'true' && (github.event_name == 'pull_request' || inputs.issue-number != '') }}
       uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       env:
         COMMENT_PATH: ${{ steps.diff.outputs.comment_markdown_path }}
+        EXPLICIT_ISSUE_NUMBER: ${{ inputs.issue-number }}
       with:
         github-token: ${{ inputs.github-token }}
         script: |
@@ -151,7 +156,10 @@ runs:
           const marker = '<!-- guardian-vulnerability-diff -->';
           const fullBody = `${marker}\n${body}`;
           const { owner, repo } = context.repo;
-          const issue_number = context.payload.pull_request.number;
+          const explicit = process.env.EXPLICIT_ISSUE_NUMBER;
+          const issue_number = explicit
+            ? Number(explicit)
+            : context.payload.pull_request.number;
 
           const existing = await github.paginate(github.rest.issues.listComments, {
             owner, repo, issue_number, per_page: 100,

--- a/guardian-vulnerability-diff/action.yml
+++ b/guardian-vulnerability-diff/action.yml
@@ -43,6 +43,10 @@ inputs:
     description: "Upload vulnerability-diff response and rendered comment as a workflow artifact."
     required: false
     default: "false"
+  publish-report:
+    description: "Post the diff comment on the PR, append the counts table to the job summary, and upload the diff response as an artifact. Always suppressed for public repositories regardless of this flag."
+    required: false
+    default: "true"
 
 outputs:
   added_count:
@@ -76,6 +80,20 @@ runs:
         if [ -z "${{ inputs.guardian-url }}" ] || [ -z "${{ inputs.guardian-key }}" ]; then
           echo "guardian-url and guardian-key are required." >&2
           exit 1
+        fi
+
+    - name: Evaluate report publishing
+      id: report_visibility
+      shell: bash
+      run: |
+        REPO_VISIBILITY="${{ github.event.repository.visibility }}"
+        if [ "${{ inputs.publish-report }}" = "true" ] && [ "$REPO_VISIBILITY" = "public" ]; then
+          echo "Report publishing suppressed: repository is public. Vulnerability details will not be included in the PR comment, job summary, or log artifacts." >&2
+          echo "enabled=false" >> "$GITHUB_OUTPUT"
+        elif [ "${{ inputs.publish-report }}" = "true" ]; then
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "enabled=false" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Prepare Guardian diff log artifact name
@@ -123,6 +141,7 @@ runs:
           --verbosity "${{ inputs.verbosity }}"
           --fail-on-added-critical "${{ inputs.fail-on-added-critical }}"
           --debug "${{ inputs.debug }}"
+          --publish-report "${{ steps.report_visibility.outputs.enabled }}"
           --output-dir "$response_dir"
         )
 
@@ -134,7 +153,7 @@ runs:
 
     - name: Post PR comment
       id: post_comment
-      if: ${{ success() && inputs.post-comment == 'true' && (github.event_name == 'pull_request' || inputs.issue-number != '') }}
+      if: ${{ success() && steps.report_visibility.outputs.enabled == 'true' && inputs.post-comment == 'true' && (github.event_name == 'pull_request' || inputs.issue-number != '') }}
       uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       env:
         COMMENT_PATH: ${{ steps.diff.outputs.comment_markdown_path }}
@@ -181,7 +200,7 @@ runs:
           core.setOutput('comment_url', comment.html_url);
 
     - name: Upload Guardian diff logs
-      if: ${{ always() && inputs.upload-logs == 'true' }}
+      if: ${{ always() && inputs.upload-logs == 'true' && steps.report_visibility.outputs.enabled == 'true' }}
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: ${{ steps.log_artifact.outputs.name }}

--- a/guardian-vulnerability-diff/action.yml
+++ b/guardian-vulnerability-diff/action.yml
@@ -73,11 +73,14 @@ runs:
   steps:
     - name: Validate Guardian API inputs
       shell: bash
+      env:
+        GUARDIAN_URL: ${{ inputs.guardian-url }}
+        GUARDIAN_KEY: ${{ inputs.guardian-key }}
       run: |
-        echo "::add-mask::${{ inputs.guardian-url }}"
-        echo "::add-mask::${{ inputs.guardian-key }}"
+        echo "::add-mask::$GUARDIAN_URL"
+        echo "::add-mask::$GUARDIAN_KEY"
 
-        if [ -z "${{ inputs.guardian-url }}" ] || [ -z "${{ inputs.guardian-key }}" ]; then
+        if [ -z "$GUARDIAN_URL" ] || [ -z "$GUARDIAN_KEY" ]; then
           echo "guardian-url and guardian-key are required." >&2
           exit 1
         fi
@@ -130,26 +133,36 @@ runs:
     - name: Run Guardian vulnerability diff
       id: diff
       shell: bash
+      env:
+        GUARDIAN_URL: ${{ inputs.guardian-url }}
+        GUARDIAN_KEY: ${{ inputs.guardian-key }}
+        PRISMA_SCAN_PATH: ${{ inputs.prisma-scan-path }}
+        PRODUCT_NAME: ${{ inputs.product-name }}
+        VERBOSITY: ${{ inputs.verbosity }}
+        FAIL_ON_ADDED_CRITICAL: ${{ inputs.fail-on-added-critical }}
+        DEBUG: ${{ inputs.debug }}
+        PUBLISH_REPORT: ${{ steps.report_visibility.outputs.enabled }}
+        ACTION_PATH: ${{ github.action_path }}
       run: |
         response_dir="${RUNNER_TEMP}/guardian-vulnerability-diff"
         mkdir -p "$response_dir"
 
         args=(
-          --guardian-url "${{ inputs.guardian-url }}"
-          --guardian-key "${{ inputs.guardian-key }}"
-          --prisma-scan-path "${{ inputs.prisma-scan-path }}"
-          --verbosity "${{ inputs.verbosity }}"
-          --fail-on-added-critical "${{ inputs.fail-on-added-critical }}"
-          --debug "${{ inputs.debug }}"
-          --publish-report "${{ steps.report_visibility.outputs.enabled }}"
+          --guardian-url "$GUARDIAN_URL"
+          --guardian-key "$GUARDIAN_KEY"
+          --prisma-scan-path "$PRISMA_SCAN_PATH"
+          --verbosity "$VERBOSITY"
+          --fail-on-added-critical "$FAIL_ON_ADDED_CRITICAL"
+          --debug "$DEBUG"
+          --publish-report "$PUBLISH_REPORT"
           --output-dir "$response_dir"
         )
 
-        if [ -n "${{ inputs.product-name }}" ]; then
-          args+=(--product-name "${{ inputs.product-name }}")
+        if [ -n "$PRODUCT_NAME" ]; then
+          args+=(--product-name "$PRODUCT_NAME")
         fi
 
-        bash "${{ github.action_path }}/vulnerability_diff_via_api.sh" "${args[@]}"
+        bash "$ACTION_PATH/vulnerability_diff_via_api.sh" "${args[@]}"
 
     - name: Post PR comment
       id: post_comment

--- a/guardian-vulnerability-diff/action.yml
+++ b/guardian-vulnerability-diff/action.yml
@@ -1,0 +1,182 @@
+name: "Guardian Vulnerability Diff"
+description: "Calls Guardian /api/v1/vulnerability-diff for a Prisma scan and posts the rendered markdown as a PR comment."
+
+inputs:
+  guardian-url:
+    description: "Guardian API base URL."
+    required: true
+  guardian-key:
+    description: "Guardian API bearer token."
+    required: true
+  prisma-scan-path:
+    description: "Path to the local Prisma scan JSON file."
+    required: true
+  product-name:
+    description: "Guardian product name. Defaults to the repository name without the org."
+    required: false
+    default: ""
+  verbosity:
+    description: "Markdown verbosity: summary | compact | detailed."
+    required: false
+    default: "detailed"
+  post-comment:
+    description: "When true and the run is on a pull_request, post comment_markdown as a PR comment (or update the previous one)."
+    required: false
+    default: "true"
+  fail-on-added-critical:
+    description: "Exit non-zero when by_severity.Critical.added > 0."
+    required: false
+    default: "false"
+  debug:
+    description: "Pass through ?debug=true and dump the diagnostics block."
+    required: false
+    default: "false"
+  github-token:
+    description: "Token used by the PR-comment step. Defaults to the workflow token."
+    required: false
+    default: ${{ github.token }}
+  upload-logs:
+    description: "Upload vulnerability-diff response and rendered comment as a workflow artifact."
+    required: false
+    default: "false"
+
+outputs:
+  added_count:
+    description: "counts.added returned by vulnerability-diff."
+    value: ${{ steps.diff.outputs.added_count }}
+  resolved_count:
+    description: "counts.resolved returned by vulnerability-diff."
+    value: ${{ steps.diff.outputs.resolved_count }}
+  changed_count:
+    description: "counts.changed returned by vulnerability-diff."
+    value: ${{ steps.diff.outputs.changed_count }}
+  critical_added_count:
+    description: "by_severity.Critical.added returned by vulnerability-diff."
+    value: ${{ steps.diff.outputs.critical_added_count }}
+  response_json:
+    description: "Compact JSON response returned by vulnerability-diff (omitted when >50KB)."
+    value: ${{ steps.diff.outputs.response_json }}
+  comment_url:
+    description: "URL of the PR comment that was created or updated."
+    value: ${{ steps.post_comment.outputs.comment_url }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Validate Guardian API inputs
+      shell: bash
+      run: |
+        echo "::add-mask::${{ inputs.guardian-url }}"
+        echo "::add-mask::${{ inputs.guardian-key }}"
+
+        if [ -z "${{ inputs.guardian-url }}" ] || [ -z "${{ inputs.guardian-key }}" ]; then
+          echo "guardian-url and guardian-key are required." >&2
+          exit 1
+        fi
+
+    - name: Prepare Guardian diff log artifact name
+      id: log_artifact
+      if: ${{ inputs.upload-logs == 'true' }}
+      shell: bash
+      env:
+        INPUT_PRODUCT_NAME: ${{ inputs.product-name }}
+        JOB_NAME: ${{ github.job }}
+        REPOSITORY_NAME: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+        sanitize() {
+          printf '%s' "$1" | tr '/:@ ' '-' | tr -cd '[:alnum:]._-'
+        }
+
+        PRODUCT_NAME="$INPUT_PRODUCT_NAME"
+        if [ -z "$PRODUCT_NAME" ]; then
+          PRODUCT_NAME="${REPOSITORY_NAME#*/}"
+        fi
+
+        PRODUCT_NAME_SAFE="$(sanitize "$PRODUCT_NAME")"
+        JOB_NAME_SAFE="$(sanitize "$JOB_NAME")"
+
+        if [ -z "$PRODUCT_NAME_SAFE" ]; then
+          PRODUCT_NAME_SAFE="repository"
+        fi
+        if [ -z "$JOB_NAME_SAFE" ]; then
+          JOB_NAME_SAFE="job"
+        fi
+
+        echo "name=guardian-vulnerability-diff-${JOB_NAME_SAFE}-${PRODUCT_NAME_SAFE}" >> "$GITHUB_OUTPUT"
+
+    - name: Run Guardian vulnerability diff
+      id: diff
+      shell: bash
+      run: |
+        response_dir="${RUNNER_TEMP}/guardian-vulnerability-diff"
+        mkdir -p "$response_dir"
+
+        args=(
+          --guardian-url "${{ inputs.guardian-url }}"
+          --guardian-key "${{ inputs.guardian-key }}"
+          --prisma-scan-path "${{ inputs.prisma-scan-path }}"
+          --verbosity "${{ inputs.verbosity }}"
+          --fail-on-added-critical "${{ inputs.fail-on-added-critical }}"
+          --debug "${{ inputs.debug }}"
+          --output-dir "$response_dir"
+        )
+
+        if [ -n "${{ inputs.product-name }}" ]; then
+          args+=(--product-name "${{ inputs.product-name }}")
+        fi
+
+        bash "${{ github.action_path }}/vulnerability_diff_via_api.sh" "${args[@]}"
+
+    - name: Post PR comment
+      id: post_comment
+      if: ${{ success() && inputs.post-comment == 'true' && github.event_name == 'pull_request' }}
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+      env:
+        COMMENT_PATH: ${{ steps.diff.outputs.comment_markdown_path }}
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const fs = require('fs');
+          const path = process.env.COMMENT_PATH;
+          if (!path || !fs.existsSync(path)) {
+            core.info(`No comment markdown produced at ${path || '(unset)'}, skipping PR comment.`);
+            return;
+          }
+          const body = fs.readFileSync(path, 'utf8').trim();
+          if (!body) {
+            core.info('Empty comment markdown, skipping PR comment.');
+            return;
+          }
+          const marker = '<!-- guardian-vulnerability-diff -->';
+          const fullBody = `${marker}\n${body}`;
+          const { owner, repo } = context.repo;
+          const issue_number = context.payload.pull_request.number;
+
+          const existing = await github.paginate(github.rest.issues.listComments, {
+            owner, repo, issue_number, per_page: 100,
+          });
+          const prior = existing.find(c => c.body && c.body.startsWith(marker));
+
+          let comment;
+          if (prior) {
+            ({ data: comment } = await github.rest.issues.updateComment({
+              owner, repo, comment_id: prior.id, body: fullBody,
+            }));
+            core.info(`Updated existing PR comment #${prior.id}`);
+          } else {
+            ({ data: comment } = await github.rest.issues.createComment({
+              owner, repo, issue_number, body: fullBody,
+            }));
+            core.info(`Created new PR comment #${comment.id}`);
+          }
+          core.setOutput('comment_url', comment.html_url);
+
+    - name: Upload Guardian diff logs
+      if: ${{ always() && inputs.upload-logs == 'true' }}
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      with:
+        name: ${{ steps.log_artifact.outputs.name }}
+        path: ${{ runner.temp }}/guardian-vulnerability-diff
+        retention-days: 30
+        if-no-files-found: warn

--- a/guardian-vulnerability-diff/vulnerability_diff_via_api.sh
+++ b/guardian-vulnerability-diff/vulnerability_diff_via_api.sh
@@ -8,6 +8,7 @@ PRISMA_SCAN_PATH=""
 VERBOSITY="detailed"
 FAIL_ON_ADDED_CRITICAL="false"
 DEBUG="false"
+PUBLISH_REPORT="true"
 OUTPUT_DIR=""
 
 usage() {
@@ -24,6 +25,9 @@ Optional:
   --verbosity <level>              summary | compact | detailed. Default: detailed
   --fail-on-added-critical <bool>  Default: false. Exit non-zero when by_severity.Critical.added > 0
   --debug <bool>                   Default: false. Pass through ?debug=true and dump diagnostics
+  --publish-report <bool>          Default: true. When false, suppresses comment markdown, detailed
+                                   step summary, diagnostics dump, and notes (numeric outputs are
+                                   always emitted). Always suppressed for public repositories.
   --output-dir <dir>               Directory for response.json and comment.md
   -h, --help
 
@@ -142,6 +146,10 @@ while [ $# -gt 0 ]; do
       DEBUG="$(normalize_bool "$2")"
       shift 2
       ;;
+    --publish-report)
+      PUBLISH_REPORT="$(normalize_bool "$2")"
+      shift 2
+      ;;
     --output-dir)
       OUTPUT_DIR="$2"
       shift 2
@@ -238,13 +246,17 @@ CRIT_ADDED="$(jq -r '.by_severity.Critical.added // 0' "$RESPONSE_FILE")"
 CRIT_RESOLVED="$(jq -r '.by_severity.Critical.resolved // 0' "$RESPONSE_FILE")"
 CRIT_CHANGED="$(jq -r '.by_severity.Critical.changed // 0' "$RESPONSE_FILE")"
 
-jq -r '.comment_markdown // ""' "$RESPONSE_FILE" > "$COMMENT_FILE"
+if [ "$PUBLISH_REPORT" = "true" ]; then
+  jq -r '.comment_markdown // ""' "$RESPONSE_FILE" > "$COMMENT_FILE"
+else
+  : > "$COMMENT_FILE"
+fi
 
 echo "Guardian vulnerability diff completed"
 echo "  added: $ADDED  resolved: $RESOLVED  changed: $CHANGED"
 echo "  critical: added=$CRIT_ADDED resolved=$CRIT_RESOLVED changed=$CRIT_CHANGED"
 
-if [ "$DEBUG" = "true" ]; then
+if [ "$DEBUG" = "true" ] && [ "$PUBLISH_REPORT" = "true" ]; then
   echo "--- diagnostics ---"
   jq '.diagnostics // "no diagnostics in response"' "$RESPONSE_FILE"
   echo "--- notes ---"
@@ -258,20 +270,24 @@ set_output critical_added_count "$CRIT_ADDED"
 set_output comment_markdown_path "$COMMENT_FILE"
 set_json_output_from_file response_json "$RESPONSE_FILE"
 
-append_step_summary "### Guardian Vulnerability Diff"
-append_step_summary "- Product: \`$PRODUCT_NAME\`"
-append_step_summary ""
-append_step_summary "| Bucket | Total | Critical |"
-append_step_summary "| --- | ---: | ---: |"
-append_step_summary "| Added | $ADDED | $CRIT_ADDED |"
-append_step_summary "| Resolved | $RESOLVED | $CRIT_RESOLVED |"
-append_step_summary "| Changed | $CHANGED | $CRIT_CHANGED |"
-
-NOTES_COUNT="$(jq -r '(.notes // []) | length' "$RESPONSE_FILE")"
-if [ "$NOTES_COUNT" -gt 0 ]; then
+if [ "$PUBLISH_REPORT" = "true" ]; then
+  append_step_summary "### Guardian Vulnerability Diff"
+  append_step_summary "- Product: \`$PRODUCT_NAME\`"
   append_step_summary ""
-  append_step_summary "**Notes from Guardian:**"
-  jq -r '.notes[] | "- " + .' "$RESPONSE_FILE" >> "${GITHUB_STEP_SUMMARY:-/dev/null}" 2>/dev/null || true
+  append_step_summary "| Bucket | Total | Critical |"
+  append_step_summary "| --- | ---: | ---: |"
+  append_step_summary "| Added | $ADDED | $CRIT_ADDED |"
+  append_step_summary "| Resolved | $RESOLVED | $CRIT_RESOLVED |"
+  append_step_summary "| Changed | $CHANGED | $CRIT_CHANGED |"
+
+  NOTES_COUNT="$(jq -r '(.notes // []) | length' "$RESPONSE_FILE")"
+  if [ "$NOTES_COUNT" -gt 0 ]; then
+    append_step_summary ""
+    append_step_summary "**Notes from Guardian:**"
+    jq -r '.notes[] | "- " + .' "$RESPONSE_FILE" >> "${GITHUB_STEP_SUMMARY:-/dev/null}" 2>/dev/null || true
+  fi
+else
+  append_step_summary "### Guardian Vulnerability Diff completed — details suppressed (public repo)."
 fi
 
 if [ "$FAIL_ON_ADDED_CRITICAL" = "true" ] && [ "$CRIT_ADDED" -gt 0 ]; then

--- a/guardian-vulnerability-diff/vulnerability_diff_via_api.sh
+++ b/guardian-vulnerability-diff/vulnerability_diff_via_api.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GUARDIAN_URL=""
+GUARDIAN_KEY=""
+PRODUCT_NAME=""
+PRISMA_SCAN_PATH=""
+VERBOSITY="detailed"
+FAIL_ON_ADDED_CRITICAL="false"
+DEBUG="false"
+OUTPUT_DIR=""
+
+usage() {
+  cat <<'EOF'
+Call Guardian /api/v1/vulnerability-diff for a Prisma scan and post results.
+
+Required:
+  --guardian-url <url>
+  --guardian-key <token>
+  --prisma-scan-path <path>        Path to prisma_scan.json
+
+Optional:
+  --product-name <name>            Defaults to the repository name without the org
+  --verbosity <level>              summary | compact | detailed. Default: detailed
+  --fail-on-added-critical <bool>  Default: false. Exit non-zero when by_severity.Critical.added > 0
+  --debug <bool>                   Default: false. Pass through ?debug=true and dump diagnostics
+  --output-dir <dir>               Directory for response.json and comment.md
+  -h, --help
+
+Example:
+  guardian-vulnerability-diff/vulnerability_diff_via_api.sh \
+    --guardian-url https://guardian.com \
+    --guardian-key "$GUARDIAN_API_TOKEN" \
+    --prisma-scan-path ./prisma_scan.json \
+    --product-name harness-delegate \
+    --verbosity detailed
+EOF
+}
+
+require_command() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "ERROR: required command not found: $cmd" >&2
+    exit 1
+  fi
+}
+
+normalize_bool() {
+  local value="$1"
+  case "$value" in
+    true|false)
+      printf '%s\n' "$value"
+      ;;
+    *)
+      echo "ERROR: invalid boolean value: $value (expected true or false)" >&2
+      exit 1
+      ;;
+  esac
+}
+
+require_value() {
+  local flag="$1"
+  local value="$2"
+  if [ -z "$value" ]; then
+    echo "ERROR: missing required argument: $flag" >&2
+    usage
+    exit 1
+  fi
+}
+
+default_product_name() {
+  if [ -n "${GITHUB_REPOSITORY:-}" ]; then
+    printf '%s\n' "${GITHUB_REPOSITORY#*/}"
+  fi
+}
+
+print_response() {
+  local file="$1"
+  if jq -e . "$file" >/dev/null 2>&1; then
+    jq . "$file"
+  else
+    cat "$file"
+  fi
+}
+
+set_output() {
+  local name="$1"
+  local value="$2"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    printf '%s=%s\n' "$name" "$value" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+set_json_output_from_file() {
+  local name="$1"
+  local file="$2"
+  if [ -n "${GITHUB_OUTPUT:-}" ] && [ -f "$file" ]; then
+    local compact_json
+    compact_json="$(jq -c . "$file")"
+    if [ "${#compact_json}" -gt 50000 ]; then
+      echo "WARNING: skipping GitHub output '$name' because the JSON payload exceeds 50000 bytes" >&2
+      return 0
+    fi
+    printf '%s=%s\n' "$name" "$compact_json" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+append_step_summary() {
+  local line="$1"
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    printf '%s\n' "$line" >> "$GITHUB_STEP_SUMMARY"
+  fi
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --guardian-url)
+      GUARDIAN_URL="$2"
+      shift 2
+      ;;
+    --guardian-key|--guardian-token)
+      GUARDIAN_KEY="$2"
+      shift 2
+      ;;
+    --product-name)
+      PRODUCT_NAME="$2"
+      shift 2
+      ;;
+    --prisma-scan-path)
+      PRISMA_SCAN_PATH="$2"
+      shift 2
+      ;;
+    --verbosity)
+      VERBOSITY="$2"
+      shift 2
+      ;;
+    --fail-on-added-critical)
+      FAIL_ON_ADDED_CRITICAL="$(normalize_bool "$2")"
+      shift 2
+      ;;
+    --debug)
+      DEBUG="$(normalize_bool "$2")"
+      shift 2
+      ;;
+    --output-dir)
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+require_command curl
+require_command jq
+
+require_value --guardian-url "$GUARDIAN_URL"
+require_value --guardian-key "$GUARDIAN_KEY"
+require_value --prisma-scan-path "$PRISMA_SCAN_PATH"
+
+if [ ! -f "$PRISMA_SCAN_PATH" ]; then
+  echo "ERROR: prisma scan file not found: $PRISMA_SCAN_PATH" >&2
+  exit 1
+fi
+
+case "$VERBOSITY" in
+  summary|compact|detailed) ;;
+  *)
+    echo "ERROR: invalid --verbosity: $VERBOSITY (expected summary | compact | detailed)" >&2
+    exit 1
+    ;;
+esac
+
+if [ -z "$PRODUCT_NAME" ]; then
+  PRODUCT_NAME="$(default_product_name)"
+fi
+require_value --product-name "$PRODUCT_NAME"
+
+GUARDIAN_URL="${GUARDIAN_URL%/}"
+
+if [ -z "$OUTPUT_DIR" ]; then
+  OUTPUT_DIR="$(mktemp -d)"
+else
+  mkdir -p "$OUTPUT_DIR"
+fi
+
+RESPONSE_FILE="$OUTPUT_DIR/vulnerability_diff_response.json"
+COMMENT_FILE="$OUTPUT_DIR/comment.md"
+
+URL="$GUARDIAN_URL/api/v1/vulnerability-diff"
+if [ "$DEBUG" = "true" ]; then
+  URL="$URL?debug=true"
+fi
+
+CURL_ARGS=(
+  -sS
+  -o "$RESPONSE_FILE"
+  -w "%{http_code}"
+  -X POST
+  -H "Authorization: Bearer $GUARDIAN_KEY"
+  --form "prisma_scan=@$PRISMA_SCAN_PATH"
+  --form-string "product_name=$PRODUCT_NAME"
+  --form-string "verbosity=$VERBOSITY"
+  --form-string "render_markdown=true"
+)
+
+echo "Running Guardian vulnerability diff via $URL"
+echo "  Product: $PRODUCT_NAME"
+echo "  Prisma scan path: $PRISMA_SCAN_PATH"
+echo "  Verbosity: $VERBOSITY"
+echo "  Debug: $DEBUG"
+
+# Single retry for 5xx; 4xx is terminal.
+HTTP_STATUS="$(curl "${CURL_ARGS[@]}" "$URL")"
+if [ "$HTTP_STATUS" -ge 500 ]; then
+  echo "Transient HTTP $HTTP_STATUS from vulnerability-diff; retrying once after 5s..." >&2
+  sleep 5
+  HTTP_STATUS="$(curl "${CURL_ARGS[@]}" "$URL")"
+fi
+
+if [ "$HTTP_STATUS" -lt 200 ] || [ "$HTTP_STATUS" -ge 300 ]; then
+  echo "ERROR: vulnerability-diff failed with HTTP $HTTP_STATUS" >&2
+  print_response "$RESPONSE_FILE"
+  exit 1
+fi
+
+ADDED="$(jq -r '.counts.added // 0' "$RESPONSE_FILE")"
+RESOLVED="$(jq -r '.counts.resolved // 0' "$RESPONSE_FILE")"
+CHANGED="$(jq -r '.counts.changed // 0' "$RESPONSE_FILE")"
+CRIT_ADDED="$(jq -r '.by_severity.Critical.added // 0' "$RESPONSE_FILE")"
+CRIT_RESOLVED="$(jq -r '.by_severity.Critical.resolved // 0' "$RESPONSE_FILE")"
+CRIT_CHANGED="$(jq -r '.by_severity.Critical.changed // 0' "$RESPONSE_FILE")"
+
+jq -r '.comment_markdown // ""' "$RESPONSE_FILE" > "$COMMENT_FILE"
+
+echo "Guardian vulnerability diff completed"
+echo "  added: $ADDED  resolved: $RESOLVED  changed: $CHANGED"
+echo "  critical: added=$CRIT_ADDED resolved=$CRIT_RESOLVED changed=$CRIT_CHANGED"
+
+if [ "$DEBUG" = "true" ]; then
+  echo "--- diagnostics ---"
+  jq '.diagnostics // "no diagnostics in response"' "$RESPONSE_FILE"
+  echo "--- notes ---"
+  jq '.notes // []' "$RESPONSE_FILE"
+fi
+
+set_output added_count "$ADDED"
+set_output resolved_count "$RESOLVED"
+set_output changed_count "$CHANGED"
+set_output critical_added_count "$CRIT_ADDED"
+set_output comment_markdown_path "$COMMENT_FILE"
+set_json_output_from_file response_json "$RESPONSE_FILE"
+
+append_step_summary "### Guardian Vulnerability Diff"
+append_step_summary "- Product: \`$PRODUCT_NAME\`"
+append_step_summary ""
+append_step_summary "| Bucket | Total | Critical |"
+append_step_summary "| --- | ---: | ---: |"
+append_step_summary "| Added | $ADDED | $CRIT_ADDED |"
+append_step_summary "| Resolved | $RESOLVED | $CRIT_RESOLVED |"
+append_step_summary "| Changed | $CHANGED | $CRIT_CHANGED |"
+
+NOTES_COUNT="$(jq -r '(.notes // []) | length' "$RESPONSE_FILE")"
+if [ "$NOTES_COUNT" -gt 0 ]; then
+  append_step_summary ""
+  append_step_summary "**Notes from Guardian:**"
+  jq -r '.notes[] | "- " + .' "$RESPONSE_FILE" >> "${GITHUB_STEP_SUMMARY:-/dev/null}" 2>/dev/null || true
+fi
+
+if [ "$FAIL_ON_ADDED_CRITICAL" = "true" ] && [ "$CRIT_ADDED" -gt 0 ]; then
+  echo "ERROR: vulnerability-diff introduces $CRIT_ADDED new Critical CVEs and fail-on-added-critical is true." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- New composite action wrapping Guardian's `POST /api/v1/vulnerability-diff` endpoint.
- Uploads a Prisma scan, posts the rendered markdown summary back as a PR comment (hide-and-update via a marker so re-runs don't duplicate), and optionally fails the workflow when new Critical CVEs are introduced.
- Mirrors the existing `guardian-*` actions: same input-validation/log-artifact patterns as `guardian-db-sync` and `guardian-vulnerability-gate`; same multipart-curl pattern as `guardian-release-gate`.

## Inputs
Required: `guardian-url`, `guardian-key`, `prisma-scan-path`.
Optional: `product-name`, `verbosity` (summary/compact/detailed), `post-comment`, `fail-on-added-critical`, `debug`, `issue-number` (for workflow_run callers), `github-token`, `upload-logs`.

## Outputs
`added_count`, `resolved_count`, `changed_count`, `critical_added_count`, `response_json` (omitted when >50KB), `comment_url`.