### PR TITLE
chore(DATAGO-137780): bump maas-build-actions image to May 25 build (sha256:ffc84fb)

### DIFF
--- a/.github/actions/cicd-helper/action.yaml
+++ b/.github/actions/cicd-helper/action.yaml
@@ -254,5 +254,5 @@ runs:
           -v "${RUNNER_TEMP}:${RUNNER_TEMP}" \
           -v "${GITHUB_OUTPUT_DIR}:${GITHUB_OUTPUT_DIR}" \
           --workdir /github/workspace \
-          "ghcr.io/${OWNER}/maas-build-actions@sha256:15c44ebad24e907c5691a136e7170a5e665f540e244446d82c33112b7ce050cd" \
+          "ghcr.io/${OWNER}/maas-build-actions@sha256:ffc84fb247270876307e3439c54d890f0eb76c33ad7b15a22b7ea46837830508" \
           /bin/sh -c 'source /maas-build-actions/venv/bin/activate && $RC_PYTHON $RC_HELPER_SCRIPT'

--- a/.github/actions/fossa-guard/action.yaml
+++ b/.github/actions/fossa-guard/action.yaml
@@ -178,5 +178,5 @@ runs:
           -v "${RUNNER_TEMP}:${RUNNER_TEMP}" \
           -v "${GITHUB_OUTPUT_DIR}:${GITHUB_OUTPUT_DIR}" \
           --workdir /github/workspace \
-          "ghcr.io/${OWNER}/maas-build-actions@sha256:15c44ebad24e907c5691a136e7170a5e665f540e244446d82c33112b7ce050cd" \
+          "ghcr.io/${OWNER}/maas-build-actions@sha256:ffc84fb247270876307e3439c54d890f0eb76c33ad7b15a22b7ea46837830508" \
           /bin/sh -c 'source /maas-build-actions/venv/bin/activate && python3 /maas-build-actions/scripts/fossa-guard/fossa_guard.py'

--- a/.github/actions/generate-fossa-report/action.yaml
+++ b/.github/actions/generate-fossa-report/action.yaml
@@ -97,5 +97,5 @@ runs:
           -v "${RUNNER_TEMP}:${RUNNER_TEMP}" \
           -v "${GITHUB_OUTPUT_DIR}:${GITHUB_OUTPUT_DIR}" \
           --workdir /github/workspace \
-          "ghcr.io/${OWNER}/maas-build-actions@sha256:bf604b234720f3a970e0a0cc9d6a07f6e991fa791d2e38ac065c32acedc88050" \
+          "ghcr.io/${OWNER}/maas-build-actions@sha256:ffc84fb247270876307e3439c54d890f0eb76c33ad7b15a22b7ea46837830508" \
           /bin/sh -c 'bash /maas-build-actions/actions/generate-fossa-report/generate-report.sh'

--- a/.github/workflows/hatch_release_pypi.yml
+++ b/.github/workflows/hatch_release_pypi.yml
@@ -161,7 +161,7 @@ jobs:
             -e GH_ORG \
             -e GH_REPO \
             -e GITHUB_SHA \
-            ghcr.io/${OWNER}/maas-build-actions@sha256:15c44ebad24e907c5691a136e7170a5e665f540e244446d82c33112b7ce050cd \
+            ghcr.io/${OWNER}/maas-build-actions@sha256:ffc84fb247270876307e3439c54d890f0eb76c33ad7b15a22b7ea46837830508 \
             /bin/sh -c '. $VIRTUAL_ENV/bin/activate && cd $ACTIONS_PATH/prisma-vulnerability-checker && python prisma_vulnerability_checker.py'
       - name: Run SonarQube Hotspot Check
         if: ${{ fromJson(inputs.sonarqube_hotspot_check) }}
@@ -181,7 +181,7 @@ jobs:
             -e SONARQUBE_PROJECT_MAIN_BRANCH \
             -e SONARQUBE_QUERY_TOKEN \
             -e SONARQUBE_HOTSPOTS_API_URL \
-            ghcr.io/${OWNER}/maas-build-actions@sha256:15c44ebad24e907c5691a136e7170a5e665f540e244446d82c33112b7ce050cd \
+            ghcr.io/${OWNER}/maas-build-actions@sha256:ffc84fb247270876307e3439c54d890f0eb76c33ad7b15a22b7ea46837830508 \
             /bin/sh -c '. $VIRTUAL_ENV/bin/activate && cd $ACTIONS_PATH/sonarqube-hotspot-checker && python sonarqube_checker.py'
 
       - name: Setup Node.js

--- a/.github/workflows/hatch_release_security_checks.yml
+++ b/.github/workflows/hatch_release_security_checks.yml
@@ -136,7 +136,7 @@ jobs:
             -e GH_ORG \
             -e GH_REPO \
             -e GITHUB_SHA \
-            ghcr.io/${OWNER}/maas-build-actions@sha256:15c44ebad24e907c5691a136e7170a5e665f540e244446d82c33112b7ce050cd \
+            ghcr.io/${OWNER}/maas-build-actions@sha256:ffc84fb247270876307e3439c54d890f0eb76c33ad7b15a22b7ea46837830508 \
             /bin/sh -c '. $VIRTUAL_ENV/bin/activate && cd $ACTIONS_PATH/prisma-vulnerability-checker && python prisma_vulnerability_checker.py'
 
       - name: Run SonarQube Hotspot Check
@@ -159,5 +159,5 @@ jobs:
             -e SONARQUBE_PROJECT_MAIN_BRANCH \
             -e SONARQUBE_QUERY_TOKEN \
             -e SONARQUBE_HOTSPOTS_API_URL \
-            ghcr.io/${OWNER}/maas-build-actions@sha256:15c44ebad24e907c5691a136e7170a5e665f540e244446d82c33112b7ce050cd \
+            ghcr.io/${OWNER}/maas-build-actions@sha256:ffc84fb247270876307e3439c54d890f0eb76c33ad7b15a22b7ea46837830508 \
             /bin/sh -c '. $VIRTUAL_ENV/bin/activate && cd $ACTIONS_PATH/sonarqube-hotspot-checker && python sonarqube_checker.py'


### PR DESCRIPTION
### What is the purpose of this change?

Bumps the `ghcr.io/solacedev/maas-build-actions` image digest across all composite actions and reusable workflows to the latest May 25 build (`sha256:ffc84fb247270876307e3439c54d890f0eb76c33ad7b15a22b7ea46837830508`).

The new image includes the fix for the `revisionScanId` race condition (DATAGO-137780) where the FOSSA guard's issues query would 404 when FOSSA replaced the auto-resolved scan ID with a newer one before the issues call completed. The previous behaviour pinned `scope[revisionScanId]` to a value captured at resolve-time; if a concurrent scan superseded it, the `/api/v2/issues` endpoint returned 404 instead of falling back to the current scan — causing false CI failures on otherwise healthy projects.

### How is this accomplished?

Single SHA digest update across 5 files:

- `.github/actions/cicd-helper/action.yaml`
- `.github/actions/fossa-guard/action.yaml`
- `.github/actions/generate-fossa-report/action.yaml`
- `.github/workflows/hatch_release_pypi.yml`
- `.github/workflows/hatch_release_security_checks.yml`

Previous digests (`sha256:15c44eb` and `sha256:bf604b2`) are both replaced with `sha256:ffc84fb`.

### Anything reviewers should focus on/be aware of?

- Confirm the new image digest matches the May 25 maas-build-actions release
- No logic changes — purely an image pin bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)