### PR TITLE
feat: add guardian_product_name input to prisma-cloud-scan

### DIFF
--- a/prisma-cloud-scan/README.md
+++ b/prisma-cloud-scan/README.md
@@ -163,6 +163,7 @@ jobs:
 | `guardian_key` | No | empty | Guardian API bearer token. When set with `guardian_url`, uploads normalized Prisma results to Guardian |
 | `guardian_product_version` | No | repo default branch | Guardian product version path segment. Defaults to the repository default branch when Guardian upload is enabled |
 | `guardian_product_full_version` | No | empty | Guardian product full version path segment. Required when Guardian upload is enabled |
+| `guardian_product_name` | No | `image_repo` | Guardian product name override. Use when the Guardian product diverges from the docker image repo — e.g. one repo ships multiple Guardian products from a single shared image, distinguished only by tag prefix |
 
 ## Outputs
 

--- a/prisma-cloud-scan/action.yml
+++ b/prisma-cloud-scan/action.yml
@@ -62,6 +62,10 @@ inputs:
     description: "Optional Guardian product full version path segment. Required when Guardian upload is enabled."
     required: false
     default: ""
+  guardian_product_name:
+    description: "Optional Guardian product name override. Defaults to `image_repo` (or the GitHub repo name). Use when the Guardian product name diverges from the docker image repo — e.g. a repo that ships multiple Guardian products from one shared image, distinguished only by tag prefix."
+    required: false
+    default: ""
 
 outputs:
   scan_passed:
@@ -464,7 +468,8 @@ runs:
         ACTION_PATH: ${{ github.action_path }}
         GUARDIAN_URL: ${{ inputs.guardian_url }}
         GUARDIAN_KEY: ${{ inputs.guardian_key }}
-        PRODUCT_NAME: ${{ steps.set_repo_name.outputs.repo_name }}
+        IMAGE_REPO_NAME: ${{ steps.set_repo_name.outputs.repo_name }}
+        GUARDIAN_PRODUCT_NAME_OVERRIDE: ${{ inputs.guardian_product_name }}
         INPUT_PRODUCT_VERSION: ${{ inputs.guardian_product_version }}
         DEFAULT_BRANCH: ${{ github.event.repository.default_branch || '' }}
         PRODUCT_FULL_VERSION: ${{ inputs.guardian_product_full_version }}
@@ -472,6 +477,16 @@ runs:
         PRISMA_SCAN_URL: ${{ steps.scan_image.outputs.console_link }}
       run: |
         set +e
+
+        # Guardian product name resolution:
+        #   1. explicit guardian_product_name input — used when the Guardian
+        #      product diverges from the docker image_repo (e.g. multiple
+        #      products sharing one image, distinguished by tag prefix).
+        #   2. fall back to image_repo (the docker repo name).
+        PRODUCT_NAME="$GUARDIAN_PRODUCT_NAME_OVERRIDE"
+        if [ -z "$PRODUCT_NAME" ]; then
+          PRODUCT_NAME="$IMAGE_REPO_NAME"
+        fi
 
         PRODUCT_VERSION="$INPUT_PRODUCT_VERSION"
         if [ -z "$PRODUCT_VERSION" ]; then


### PR DESCRIPTION
## Summary

Adds an optional \`guardian_product_name\` input to \`prisma-cloud-scan\` so the Guardian product name can be set independently of \`image_repo\`. Defaults to \`image_repo\` for backwards compatibility — no behavior change for existing callers.

## Why

Today the action derives the docker pull target AND the Guardian product name from the same \`image_repo\` input. That's fine when they match (the common case for one-product-per-repo, e.g. \`solace-agent-mesh-enterprise\`), but breaks for repos that ship multiple Guardian products from one shared image distinguished only by tag prefix.

**Concrete case** — \`solace-agent-mesh-go\` ships two products:
- \`solace-agent-mesh-go\` → ECR \`868978040651.dkr.ecr.us-east-1.amazonaws.com/solace-agent-mesh-go:<ver>-<sha>\`
- \`solace-agent-mesh-go-str\` → ECR \`868978040651.dkr.ecr.us-east-1.amazonaws.com/solace-agent-mesh-go:str-<ver>-<sha>\`

Both Guardian products are registered in pubsubplus-guardian (DATAGO-139003); str carries \`parent_products: [solace-agent-mesh-go]\` + \`ecr_image_name: solace-agent-mesh-go\` so its nightly scans pull from the right place. The release-readiness gate also needs to upload Prisma scans per-product, which without this input requires duplicating the action's upload logic inline.

## Usage

\`\`\`yaml
# Without override (existing behavior): Guardian product == image_repo
- uses: SolaceDev/solace-public-workflows/prisma-cloud-scan@<sha>
  with:
    image_repo: solace-agent-mesh-enterprise
    guardian_url: \${{ vars.GUARDIAN_API_URL }}
    guardian_key: \${{ secrets.GUARDIAN_API_TOKEN }}
    guardian_product_full_version: \${{ needs.context.outputs.version }}

# With override: docker pulls from solace-agent-mesh-go, uploads to Guardian
# product solace-agent-mesh-go-str
- uses: SolaceDev/solace-public-workflows/prisma-cloud-scan@<sha>
  with:
    image_repo: solace-agent-mesh-go
    image_tag: str-1.33.0-abc123
    guardian_url: \${{ vars.GUARDIAN_API_URL }}
    guardian_key: \${{ secrets.GUARDIAN_API_TOKEN }}
    guardian_product_name: solace-agent-mesh-go-str
    guardian_product_full_version: 1.33.0
\`\`\`

## Test plan
- [x] YAML parses (\`python3 -c 'import yaml; yaml.safe_load(open(\"prisma-cloud-scan/action.yml\"))'\`)
- [ ] Caller verification — sam-go's release-readiness-check.yaml will switch from inline \`curl\` upload to the action's native upload once this lands