### PR TITLE
feat(DATAGO-139003): add guardian_product_name input to prisma-cloud-scan

### DIFF
--- a/prisma-cloud-scan/README.md
+++ b/prisma-cloud-scan/README.md
@@ -163,6 +163,7 @@ jobs:
 | `guardian_key` | No | empty | Guardian API bearer token. When set with `guardian_url`, uploads normalized Prisma results to Guardian |
 | `guardian_product_version` | No | repo default branch | Guardian product version path segment. Defaults to the repository default branch when Guardian upload is enabled |
 | `guardian_product_full_version` | No | empty | Guardian product full version path segment. Required when Guardian upload is enabled |
+| `guardian_product_name` | No | `image_repo` | Guardian product name override. Use when the Guardian product diverges from the docker image repo — e.g. one repo ships multiple Guardian products from a single shared image, distinguished only by tag prefix |
 
 ## Outputs
 

--- a/prisma-cloud-scan/action.yml
+++ b/prisma-cloud-scan/action.yml
@@ -62,6 +62,10 @@ inputs:
     description: "Optional Guardian product full version path segment. Required when Guardian upload is enabled."
     required: false
     default: ""
+  guardian_product_name:
+    description: "Optional Guardian product name override. Defaults to `image_repo` (or the GitHub repo name). Use when the Guardian product name diverges from the docker image repo — e.g. a repo that ships multiple Guardian products from one shared image, distinguished only by tag prefix."
+    required: false
+    default: ""
 
 outputs:
   scan_passed:
@@ -464,7 +468,8 @@ runs:
         ACTION_PATH: ${{ github.action_path }}
         GUARDIAN_URL: ${{ inputs.guardian_url }}
         GUARDIAN_KEY: ${{ inputs.guardian_key }}
-        PRODUCT_NAME: ${{ steps.set_repo_name.outputs.repo_name }}
+        IMAGE_REPO_NAME: ${{ steps.set_repo_name.outputs.repo_name }}
+        GUARDIAN_PRODUCT_NAME_OVERRIDE: ${{ inputs.guardian_product_name }}
         INPUT_PRODUCT_VERSION: ${{ inputs.guardian_product_version }}
         DEFAULT_BRANCH: ${{ github.event.repository.default_branch || '' }}
         PRODUCT_FULL_VERSION: ${{ inputs.guardian_product_full_version }}
@@ -472,6 +477,16 @@ runs:
         PRISMA_SCAN_URL: ${{ steps.scan_image.outputs.console_link }}
       run: |
         set +e
+
+        # Guardian product name resolution:
+        #   1. explicit guardian_product_name input — used when the Guardian
+        #      product diverges from the docker image_repo (e.g. multiple
+        #      products sharing one image, distinguished by tag prefix).
+        #   2. fall back to image_repo (the docker repo name).
+        PRODUCT_NAME="$GUARDIAN_PRODUCT_NAME_OVERRIDE"
+        if [ -z "$PRODUCT_NAME" ]; then
+          PRODUCT_NAME="$IMAGE_REPO_NAME"
+        fi
 
         PRODUCT_VERSION="$INPUT_PRODUCT_VERSION"
         if [ -z "$PRODUCT_VERSION" ]; then


### PR DESCRIPTION
### What is the purpose of this change?

Adds an optional `guardian_product_name` input to the `prisma-cloud-scan` action so callers can override the Guardian product name when it diverges from the docker image repo. This unblocks repos that ship multiple Guardian products from a single shared image (distinguished only by tag prefix), where the existing image-repo-derived default collapses them into one product.

### How is this accomplished?

- New optional `guardian_product_name` input on `prisma-cloud-scan/action.yml`, defaulting to empty.
- The Guardian upload step now resolves `PRODUCT_NAME` at runtime: explicit override first, then fall back to the docker image repo name (renamed env var `IMAGE_REPO_NAME` to make the fallback chain readable).
- README updated with the new input row.

### Anything reviews should focus on/be aware of?

- Backwards compatible: when the input is unset, behavior is identical — `PRODUCT_NAME` still resolves to the image repo name.
- The env var rename (`PRODUCT_NAME` → `IMAGE_REPO_NAME`) is internal to the step; no external contract changes.
